### PR TITLE
Remove boost, switch to doctest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Format
-      run: find src include -iregex '.*\.\(c\|h\|cpp\|hpp\|cc\|hh\|cxx\|hxx\)$' | xargs clang-format -n -Werror
+      run: find src include test -iregex '.*\.\(c\|h\|cpp\|hpp\|cc\|hh\|cxx\|hxx\)$' | xargs clang-format -n -Werror
   build-nix:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get -q -y update
-          apt-get -q -y install bison curl wget unzip cmake flex libc6-dev gcc clang libxml2-dev libboost-all-dev doctest-dev
+          apt-get -q -y install bison curl wget unzip cmake flex libc6-dev gcc clang libxml2-dev doctest-dev
     - name: Build and test
       run: |
           export CTEST_OUTPUT_ON_FAILURE=1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get -q -y update
-          apt-get -q -y install bison curl wget unzip cmake flex libc6-dev gcc clang libxml2-dev libboost-all-dev
+          apt-get -q -y install bison curl wget unzip cmake flex libc6-dev gcc clang libxml2-dev libboost-all-dev doctest-dev
     - name: Build and test
       run: |
           export CTEST_OUTPUT_ON_FAILURE=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,11 +28,6 @@ find_package(BISON 3.6.0 REQUIRED)
 set(LibXml2_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/libs/LibXml2")
 find_package(LibXml2 2.9.11 REQUIRED)
 
-set(Boost_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/libs/boost")
-find_package(Boost 1.71.0 REQUIRED)
-
-message(STATUS "Boost include: ${Boost_INCLUDE_DIRS}")
-
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include/utap")
 
 set(lexer_source "${CMAKE_CURRENT_BINARY_DIR}/lexer.cc")
@@ -81,7 +76,6 @@ target_include_directories(UTAP
         ${CMAKE_CURRENT_SOURCE_DIR}/src
         ${CMAKE_CURRENT_BINARY_DIR}/include
         ${LIBXML2_INCLUDE_DIR}
-        ${Boost_INCLUDE_DIRS}
     PUBLIC
         # where top-level project will look for the library's public headers
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ libutap is licensed under the LGPL.
 
 libutap uses `cmake` to make compilation on various
 platforms easy. You will need `gcc-9` or newer, GNU make,
-`libxml2` from [XMLSoft](https://www.xmlsoft.org) (at least version 2.6.10),
-and `boost` from [Boost](https://www.boost.org).
+and `libxml2` from [XMLSoft](https://www.xmlsoft.org) (at least version 2.6.10).
 
 Run the following to compile libutap and use it in the build:
 

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
           version = "1.0.0";
           src = ./.;
           nativeBuildInputs = with pkgs; [ cmake flex bison ];
-          buildInputs = with pkgs; [ boost174 staticLibxml doctest ];
+          buildInputs = with pkgs; [ staticLibxml doctest ];
           cmakeFlags = [ "-DTESTING=ON" ];
 
           doCheck = true;
@@ -49,14 +49,13 @@
           nativePkgs = nixpkgsFor.${system};
           pkgs = crossNixpkgsFor.${system};
           staticLibxml = pkgs.libxml2.override { enableStatic = true; enableShared = false; };
-          staticBoost = pkgs.boost174.override { enableStatic = true; enableShared = false; };
         in
         pkgs.stdenv.mkDerivation {
           pname = "UTAP";
           version = "1.0.0";
           src = ./.;
           nativeBuildInputs = with nativePkgs; [ cmake flex bison ];
-          buildInputs = with pkgs; [ staticBoost staticLibxml zlib.static doctest ];
+          buildInputs = with pkgs; [ staticLibxml zlib.static doctest ];
           cmakeFlags = [ "-DTESTING=ON" "-DSTATIC=ON" "-DCMAKE_TOOLCHAIN_FILE=toolchains/mingw.cmake" ];
           WINEPATH = "${pkgs.windows.mcfgthreads}/bin;${nativePkgs.wine64Packages.stableFull}/lib/wine/x86_64-windows/";
           CROSSCOMPILING_EMULATOR = "${nativePkgs.wine64Packages.stableFull}/bin/wine64";

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
           version = "1.0.0";
           src = ./.;
           nativeBuildInputs = with pkgs; [ cmake flex bison ];
-          buildInputs = with pkgs; [ boost174 staticLibxml ];
+          buildInputs = with pkgs; [ boost174 staticLibxml doctest ];
           cmakeFlags = [ "-DTESTING=ON" ];
 
           doCheck = true;
@@ -56,7 +56,7 @@
           version = "1.0.0";
           src = ./.;
           nativeBuildInputs = with nativePkgs; [ cmake flex bison ];
-          buildInputs = with pkgs; [ staticBoost staticLibxml zlib.static ];
+          buildInputs = with pkgs; [ staticBoost staticLibxml zlib.static doctest ];
           cmakeFlags = [ "-DTESTING=ON" "-DSTATIC=ON" "-DCMAKE_TOOLCHAIN_FILE=toolchains/mingw.cmake" ];
           WINEPATH = "${pkgs.windows.mcfgthreads}/bin;${nativePkgs.wine64Packages.stableFull}/lib/wine/x86_64-windows/";
           CROSSCOMPILING_EMULATOR = "${nativePkgs.wine64Packages.stableFull}/bin/wine64";

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -23,7 +23,7 @@
 
 #include "utap/expression.h"
 
-#include <boost/format.hpp>
+#include <cassert>
 
 using std::string;
 using std::vector;
@@ -539,7 +539,7 @@ string type_t::toString() const
     case UPDATE: kind = "update"; break;
     case LSCINSTANCE: kind = "LSC instance"; break;
     case PROCESSVAR: kind = "PROCESSVAR"; break;
-    default: kind = (boost::format("type(%1%)") % getKind()).str(); break;
+    default: kind = "type(" + std::to_string(getKind()) + ")"; break;
     }
 
     auto str = std::string("(");
@@ -644,7 +644,7 @@ string type_t::toDeclarationString() const
 
     case Constants::FUNCTION: kind = "function"; break;
 
-    default: kind = (boost::format("type(%1%)") % getKind()).str(); break;
+    default: kind = "type(" + std::to_string(getKind()) + ")"; break;
     }
 
     auto str = std::string();

--- a/src/typeexception.cpp
+++ b/src/typeexception.cpp
@@ -21,73 +21,53 @@
 
 #include "utap/builder.h"
 
-#include <boost/format.hpp>
-
 namespace UTAP
 {
     TypeException UnknownIdentifierError(const std::string& name)
     {
-        return TypeException{(boost::format("$Unknown_identifier: %1%") % name).str()};
+        return TypeException{"$Unknown_identifier: %1%" + name};
     }
 
-    TypeException HasNoMemberError(const std::string& name)
-    {
-        return TypeException{(boost::format("$has_no_member_named %1%") % name).str()};
-    }
+    TypeException HasNoMemberError(const std::string& name) { return TypeException{"$has_no_member_named %1%" + name}; }
 
-    TypeException IsNotAStructError(const std::string& name)
-    {
-        return TypeException{(boost::format("%1% $is_not_a_structure") % name).str()};
-    }
+    TypeException IsNotAStructError(const std::string& name) { return TypeException{"%1% $is_not_a_structure" + name}; }
 
     TypeException DuplicateDefinitionError(const std::string& name)
     {
-        return TypeException{(boost::format("$Duplicate_definition_of %1%") % name).str()};
+        return TypeException{"$Duplicate_definition_of %1%" + name};
     }
 
-    TypeException InvalidTypeError(const std::string& name)
-    {
-        return TypeException{(boost::format("$Invalid_type %1%") % name).str()};
-    }
+    TypeException InvalidTypeError(const std::string& name) { return TypeException{"$Invalid_type %1%" + name}; }
 
-    TypeException NoSuchProcessError(const std::string& name)
-    {
-        return TypeException{(boost::format("$No_such_process: %1%") % name).str()};
-    }
+    TypeException NoSuchProcessError(const std::string& name) { return TypeException{"$No_such_process: %1%" + name}; }
 
-    TypeException NotATemplateError(const std::string& name)
-    {
-        return TypeException{(boost::format("$Not_a_template: %1%") % name).str()};
-    }
+    TypeException NotATemplateError(const std::string& name) { return TypeException{"$Not_a_template: %1%" + name}; }
 
-    TypeException NotAProcessError(const std::string& name)
-    {
-        return TypeException{(boost::format("%1% $is_not_a_process") % name).str()};
-    }
+    TypeException NotAProcessError(const std::string& name) { return TypeException{"%1% $is_not_a_process" + name}; }
 
     TypeException StrategyNotDeclaredError(const std::string& name)
     {
-        return TypeException{(boost::format("$strategy_not_declared: %1%") % name).str()};
+        return TypeException{"$strategy_not_declared: %1%" + name};
     }
 
     TypeException UnknownDynamicTemplateError(const std::string& name)
     {
-        return TypeException{(boost::format("Unknown dynamic template %1%") % name).str()};
+        return TypeException{"Unknown dynamic template %1%" + name};
     }
 
     TypeException ShadowsAVariableWarning(const std::string& name)
     {
-        return TypeException{(boost::format("%1% $shadows_a_variable") % name).str()};
+        return TypeException{"%1% $shadows_a_variable" + name};
     }
 
     TypeException CouldNotLoadLibraryError(const std::string& name)
     {
-        return TypeException{(boost::format("$Could_not_load_library_named %1%") % name).str()};
+        return TypeException{"$Could_not_load_library_named %1%" + name};
     }
 
     TypeException CouldNotLoadFunctionError(const std::string& name)
     {
-        return TypeException{(boost::format("$Could_not_load_function_named %1%") % name).str()};
+        return TypeException{"$Could_not_load_function_named %1%" + name};
     }
 
 }  // namespace UTAP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,8 +15,17 @@ add_executable(featurecheck featurechecker.cpp)
 target_link_libraries(featurecheck PRIVATE UTAP)
 
 if (TESTING)
-    find_package(Boost 1.71.0 REQUIRED COMPONENTS unit_test_framework REQUIRED)
-    add_executable(test_parser test_parser.cpp test_featurechecker.cpp test_range.cpp)
-    target_link_libraries(test_parser PRIVATE Boost::unit_test_framework UTAP)
+    find_package(doctest REQUIRED)
+    add_executable(test_parser test_parser.cpp)
+    target_link_libraries(test_parser PRIVATE doctest::doctest UTAP)
     add_test(NAME test_parser COMMAND test_parser)
+
+    add_executable(test_featurechecker test_featurechecker.cpp)
+    target_link_libraries(test_featurechecker PRIVATE doctest::doctest UTAP)
+    add_test(NAME test_featurechecker COMMAND test_featurechecker)
+
+    add_executable(test_range test_range.cpp)
+    target_link_libraries(test_range PRIVATE doctest::doctest UTAP)
+    add_test(NAME test_range COMMAND test_range)
+
 endif (TESTING)

--- a/test/test_featurechecker.cpp
+++ b/test/test_featurechecker.cpp
@@ -19,13 +19,14 @@
    USA
 */
 
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "utap/featurechecker.h"
 #include "utap/utap.h"
 
-#include <boost/test/unit_test.hpp>
-
 #include <filesystem>
 #include <fstream>
+
+#include <doctest/doctest.h>
 
 inline std::string read_content(const std::string& dir_path, const std::string& file_name)
 {
@@ -35,114 +36,110 @@ inline std::string read_content(const std::string& dir_path, const std::string& 
     return content;
 }
 
-BOOST_AUTO_TEST_SUITE(FeatureCheckerTests)
-
-BOOST_AUTO_TEST_CASE(CheckSimpleSystem)
+TEST_CASE("Simple system")
 {
     auto document = std::make_unique<UTAP::Document>();
     parseXMLBuffer(read_content(SYSTEMS_DIR, "simpleSystem.xml").c_str(), document.get(), true);
     UTAP::FeatureChecker checker(*document);
-    BOOST_CHECK(checker.getSupportedMethods().symbolic);
-    BOOST_CHECK(checker.getSupportedMethods().stochastic);
+    CHECK(checker.getSupportedMethods().symbolic);
+    CHECK(checker.getSupportedMethods().stochastic);
 }
 
-BOOST_AUTO_TEST_CASE(CheckSimpleSMCSystem)
+TEST_CASE("Simple SMC system")
 {
     auto document = std::make_unique<UTAP::Document>();
     parseXMLBuffer(read_content(SYSTEMS_DIR, "simpleSMCSystem.xml").c_str(), document.get(), true);
     UTAP::FeatureChecker checker(*document);
-    BOOST_CHECK(!checker.getSupportedMethods().symbolic);
-    BOOST_CHECK(checker.getSupportedMethods().stochastic);
+    CHECK(!checker.getSupportedMethods().symbolic);
+    CHECK(checker.getSupportedMethods().stochastic);
 }
 
-BOOST_AUTO_TEST_CASE(CheckSimpleHandshakeSystem)
+TEST_CASE("Simple handshake system")
 {
     auto document = std::make_unique<UTAP::Document>();
     parseXMLBuffer(read_content(SYSTEMS_DIR, "simpleHandshakeSystem.xml").c_str(), document.get(), true);
     UTAP::FeatureChecker checker(*document);
-    BOOST_CHECK(checker.getSupportedMethods().symbolic);
-    BOOST_CHECK(!checker.getSupportedMethods().stochastic);
+    CHECK(checker.getSupportedMethods().symbolic);
+    CHECK(!checker.getSupportedMethods().stochastic);
 }
 
-BOOST_AUTO_TEST_CASE(CheckDynamicSystem)
+TEST_CASE("Simply dynamic system")
 {
     auto document = std::make_unique<UTAP::Document>();
     parseXMLBuffer(read_content(SYSTEMS_DIR, "dynamic.xml").c_str(), document.get(), true);
     UTAP::FeatureChecker checker(*document);
-    BOOST_CHECK(!checker.getSupportedMethods().symbolic);
-    BOOST_CHECK(checker.getSupportedMethods().stochastic);
+    CHECK(!checker.getSupportedMethods().symbolic);
+    CHECK(checker.getSupportedMethods().stochastic);
 }
 
-BOOST_AUTO_TEST_CASE(CheckClockRate)
+TEST_CASE("Clock rate")
 {
     auto document = std::make_unique<UTAP::Document>();
     parseXMLBuffer(read_content(SYSTEMS_DIR, "clockrate2.xml").c_str(), document.get(), true);
     UTAP::FeatureChecker checker(*document);
-    BOOST_CHECK(!checker.getSupportedMethods().symbolic);
-    BOOST_CHECK(checker.getSupportedMethods().stochastic);
+    CHECK(!checker.getSupportedMethods().symbolic);
+    CHECK(checker.getSupportedMethods().stochastic);
 }
 
-BOOST_AUTO_TEST_CASE(CheckExpressionClockRate)
+TEST_CASE("Clock rate expression")
 {
     auto document = std::make_unique<UTAP::Document>();
     parseXMLBuffer(read_content(SYSTEMS_DIR, "rateExpression.xml").c_str(), document.get(), true);
     UTAP::FeatureChecker checker(*document);
-    BOOST_CHECK(checker.getSupportedMethods().symbolic);
-    BOOST_CHECK(checker.getSupportedMethods().stochastic);
+    CHECK(checker.getSupportedMethods().symbolic);
+    CHECK(checker.getSupportedMethods().stochastic);
 }
 
-BOOST_AUTO_TEST_CASE(CheckExpressionClockRateHybrid)
+TEST_CASE("Hybrid clock rate")
 {
     auto document = std::make_unique<UTAP::Document>();
     parseXMLBuffer(read_content(SYSTEMS_DIR, "rateExpressionHybrid.xml").c_str(), document.get(), true);
     UTAP::FeatureChecker checker(*document);
-    BOOST_CHECK(checker.getSupportedMethods().symbolic);
-    BOOST_CHECK(checker.getSupportedMethods().stochastic);
+    CHECK(checker.getSupportedMethods().symbolic);
+    CHECK(checker.getSupportedMethods().stochastic);
 }
 
-BOOST_AUTO_TEST_CASE(CheckExpressionClockRateZeroOne)
+TEST_CASE("Limited range clock rate")
 {
     auto document = std::make_unique<UTAP::Document>();
     parseXMLBuffer(read_content(SYSTEMS_DIR, "legalSymbolicRates.xml").c_str(), document.get(), true);
     UTAP::FeatureChecker checker(*document);
-    BOOST_CHECK(checker.getSupportedMethods().symbolic);
-    BOOST_CHECK(checker.getSupportedMethods().stochastic);
+    CHECK(checker.getSupportedMethods().symbolic);
+    CHECK(checker.getSupportedMethods().stochastic);
 }
 
-BOOST_AUTO_TEST_CASE(IntInvariant)
+TEST_CASE("Integer Invariant")
 {
     auto document = std::make_unique<UTAP::Document>();
     parseXMLBuffer(read_content(SYSTEMS_DIR, "int_invariant.xml").c_str(), document.get(), true);
     UTAP::FeatureChecker checker(*document);
-    BOOST_CHECK(checker.getSupportedMethods().symbolic);
-    BOOST_CHECK(checker.getSupportedMethods().stochastic);
+    CHECK(checker.getSupportedMethods().symbolic);
+    CHECK(checker.getSupportedMethods().stochastic);
 }
 
-BOOST_AUTO_TEST_CASE(UpdateHybridClock)
+TEST_CASE("Hybrid clock update")
 {
     auto document = std::make_unique<UTAP::Document>();
     parseXMLBuffer(read_content(SYSTEMS_DIR, "updateHybridClock.xml").c_str(), document.get(), true);
     UTAP::FeatureChecker checker(*document);
-    BOOST_CHECK(checker.getSupportedMethods().symbolic);
-    BOOST_CHECK(checker.getSupportedMethods().stochastic);
+    CHECK(checker.getSupportedMethods().symbolic);
+    CHECK(checker.getSupportedMethods().stochastic);
 }
 
-BOOST_AUTO_TEST_CASE(UpdateHybridAndNormalClock)
+TEST_CASE("Hybrid and normal clock update")
 {
     auto document = std::make_unique<UTAP::Document>();
     parseXMLBuffer(read_content(SYSTEMS_DIR, "updateHybridAndNormalClock.xml").c_str(), document.get(), true);
     UTAP::FeatureChecker checker(*document);
-    BOOST_CHECK(!checker.getSupportedMethods().symbolic);
-    BOOST_CHECK(checker.getSupportedMethods().stochastic);
+    CHECK(!checker.getSupportedMethods().symbolic);
+    CHECK(checker.getSupportedMethods().stochastic);
 }
 
-BOOST_AUTO_TEST_CASE(DoubleCompare)
+TEST_CASE("Double comparision")
 {
     auto document = std::make_unique<UTAP::Document>();
     parseXMLBuffer(read_content(SYSTEMS_DIR, "double_compare.xml").c_str(), document.get(), true);
     UTAP::FeatureChecker checker(*document);
-    BOOST_CHECK(!checker.getSupportedMethods().symbolic);
-    BOOST_CHECK(checker.getSupportedMethods().stochastic);
+    CHECK(!checker.getSupportedMethods().symbolic);
+    CHECK(checker.getSupportedMethods().stochastic);
 }
-
-BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -16,10 +16,10 @@
 
 #include "utap/utap.h"
 
-#define BOOST_TEST_MODULE utap parser
-#include <boost/test/included/unit_test.hpp>
-
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <fstream>
+
+#include <doctest/doctest.h>
 
 // Copied from SystemLoader.h. If we dependen on testutils, we would
 // also have to depend on the verifier, which seems impure.
@@ -32,13 +32,9 @@ inline std::string read_content(const std::string& dir_path, const std::string& 
     return content;
 }
 
-BOOST_AUTO_TEST_SUITE(BasicIOTests)
-
-BOOST_AUTO_TEST_CASE(DoubleSerializationTest)
+TEST_CASE("Double Serialization Test")
 {
     auto document = std::make_unique<UTAP::Document>();
     auto content = read_content(SYSTEMS_DIR, "ifstatement.xml");
     parseXMLBuffer(content.c_str(), document.get(), true);
 }
-
-BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_range.cpp
+++ b/test/test_range.cpp
@@ -1,109 +1,109 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "utap/range.h"
 
-#include <boost/test/unit_test.hpp>
+#include <doctest/doctest.h>
 
-BOOST_AUTO_TEST_SUITE(RangeTests)
-
-constexpr auto d_eps = std::numeric_limits<double>::epsilon();
-constexpr auto d_inf = std::numeric_limits<double>::infinity();
-constexpr auto d_ninf = -d_inf;
-constexpr auto d_max = std::numeric_limits<double>::max();
-constexpr auto d_min = std::numeric_limits<double>::lowest();
-
-constexpr auto f_eps = std::numeric_limits<float>::epsilon();
-constexpr auto f_inf = std::numeric_limits<float>::infinity();
-constexpr auto f_ninf = -d_inf;
-constexpr auto f_min = std::numeric_limits<float>::lowest();
-
-constexpr auto i_max = std::numeric_limits<int>::max();
-constexpr auto i_min = std::numeric_limits<int>::min();
-
-BOOST_AUTO_TEST_CASE(NextAferDoubleOne)
+TEST_CASE("Range Tests")
 {
-    // Tests the definition of epsilon:
-    auto d = 1.0;
-    auto next_d = UTAP::next_value(d);
-    BOOST_CHECK_EQUAL(next_d, 1.0 + d_eps);
-}
+    constexpr auto d_eps = std::numeric_limits<double>::epsilon();
+    constexpr auto d_inf = std::numeric_limits<double>::infinity();
+    constexpr auto d_ninf = -d_inf;
+    constexpr auto d_max = std::numeric_limits<double>::max();
+    constexpr auto d_min = std::numeric_limits<double>::lowest();
 
-BOOST_AUTO_TEST_CASE(NextAferFloatOne)
-{
-    // Tests the definition of epsilon:
-    auto f = 1.0f;
-    auto next_f = UTAP::next_value(f);
-    BOOST_CHECK_EQUAL(next_f, 1.0f + f_eps);
-}
+    constexpr auto f_eps = std::numeric_limits<float>::epsilon();
+    constexpr auto f_inf = std::numeric_limits<float>::infinity();
+    constexpr auto f_ninf = -d_inf;
+    constexpr auto f_min = std::numeric_limits<float>::lowest();
 
-BOOST_AUTO_TEST_CASE(NextAferDoubleMax)
-{
-    // Tests that all values converge at the infinity
-    auto d = std::numeric_limits<double>::max();
-    auto next_d = UTAP::next_value(d);
-    BOOST_CHECK_EQUAL(next_d, d_inf);
-}
+    constexpr auto i_max = std::numeric_limits<int>::max();
+    constexpr auto i_min = std::numeric_limits<int>::min();
 
-BOOST_AUTO_TEST_CASE(NextAferFloatMax)
-{
-    auto f = std::numeric_limits<float>::max();
-    auto next_f = UTAP::next_value(f);
-    BOOST_CHECK_EQUAL(next_f, f_inf);
-}
+    SUBCASE("Next after 1")
+    {
+        // Tests the definition of epsilon:
+        auto d = 1.0;
+        auto next_d = UTAP::next_value(d);
+        CHECK(next_d == 1.0 + d_eps);
+    }
 
-BOOST_AUTO_TEST_CASE(PrevBeforeDoubleLowest)
-{
-    auto d = d_min;
-    auto prev_d = UTAP::prev_value(d);
-    BOOST_CHECK_EQUAL(prev_d, d_ninf);
-}
+    SUBCASE("Next after 1f")
+    {
+        // Tests the definition of epsilon:
+        auto f = 1.0f;
+        auto next_f = UTAP::next_value(f);
+        CHECK(next_f == 1.0f + f_eps);
+    }
 
-BOOST_AUTO_TEST_CASE(PrevBeforeFloatLowest)
-{
-    auto f = f_min;
-    auto prev_f = UTAP::prev_value(f);
-    BOOST_CHECK_EQUAL(prev_f, f_ninf);
-}
+    SUBCASE("Next after max")
+    {
+        // Tests that all values converge at the infinity
+        auto d = std::numeric_limits<double>::max();
+        auto next_d = UTAP::next_value(d);
+        CHECK(next_d == d_inf);
+    }
 
-BOOST_AUTO_TEST_CASE(NextAferIntMax)
-{
-    // Tests that all values converge at the infinity
-    auto i = i_max - 1;
-    auto next_i = UTAP::next_value(i);
-    BOOST_CHECK_EQUAL(next_i, i_max);
-}
+    SUBCASE("Next after max float")
+    {
+        auto f = std::numeric_limits<float>::max();
+        auto next_f = UTAP::next_value(f);
+        CHECK(next_f == f_inf);
+    }
 
-BOOST_AUTO_TEST_CASE(PrevBeforeIntMin)
-{
-    auto i = i_min + 1;
-    auto prev_i = UTAP::prev_value(i);
-    BOOST_CHECK_EQUAL(prev_i, i_min);
-}
+    SUBCASE("Previous before lowest")
+    {
+        auto d = d_min;
+        auto prev_d = UTAP::prev_value(d);
+        CHECK(prev_d == d_ninf);
+    }
 
-BOOST_AUTO_TEST_CASE(NextAferDoubleNegInf)
-{
-    auto d = -d_inf;
-    auto next_d = UTAP::next_value(d);
-    BOOST_CHECK_EQUAL(next_d, d_min);
-}
+    SUBCASE("Previous before lowest float")
+    {
+        auto f = f_min;
+        auto prev_f = UTAP::prev_value(f);
+        CHECK(prev_f == f_ninf);
+    }
 
-BOOST_AUTO_TEST_CASE(PrevBeforeDoubleInf)
-{
-    auto d = d_inf;
-    auto prev_d = UTAP::prev_value(d);
-    BOOST_CHECK_EQUAL(prev_d, d_max);
-}
+    SUBCASE("Next after max-1")
+    {
+        // Tests that all values converge at the infinity
+        auto i = i_max - 1;
+        auto next_i = UTAP::next_value(i);
+        CHECK(next_i == i_max);
+    }
 
-BOOST_AUTO_TEST_CASE(GreaterThanInfinity)
-{
-    auto r1 = UTAP::range_t<double>(0, d_inf);
-    r1 = r1.gt(d_inf);
-    BOOST_CHECK(r1.empty());
-}
+    SUBCASE("Previous before min int")
+    {
+        auto i = i_min + 1;
+        auto prev_i = UTAP::prev_value(i);
+        CHECK(prev_i == i_min);
+    }
 
-BOOST_AUTO_TEST_CASE(LessThanNegativeInfinity)
-{
-    auto r1 = UTAP::range_t<double>(d_ninf, 0);
-    r1 = r1.lt(d_ninf);
-    BOOST_CHECK(r1.empty());
-}
+    SUBCASE("Next after double negative infinity")
+    {
+        auto d = -d_inf;
+        auto next_d = UTAP::next_value(d);
+        CHECK(next_d == d_min);
+    }
 
-BOOST_AUTO_TEST_SUITE_END()
+    SUBCASE("Previous before infinity double")
+    {
+        auto d = d_inf;
+        auto prev_d = UTAP::prev_value(d);
+        CHECK(prev_d == d_max);
+    }
+
+    SUBCASE("Greater than infinity")
+    {
+        auto r1 = UTAP::range_t<double>(0, d_inf);
+        r1 = r1.gt(d_inf);
+        CHECK(r1.empty());
+    }
+
+    SUBCASE("Less than negative double infinity")
+    {
+        auto r1 = UTAP::range_t<double>(d_ninf, 0);
+        r1 = r1.lt(d_ninf);
+        CHECK(r1.empty());
+    }
+}


### PR DESCRIPTION
Boost test had a memory leak, and rather than fix it, we are switching to doctest, as we should have long ago. This also allows us to remove boost entirely.