### PR TITLE
Update lock file: Remove upstreamed patch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652078902,
-        "narHash": "sha256-tgyNP9qkrlpmPJsUxuMrhjHnPJ+uo4Up7EQ+LyRMLMY=",
+        "lastModified": 1652792258,
+        "narHash": "sha256-gWrDLYnkFYAbKav5iphHskIdrHGF2Xg1pPcS6NRErag=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "70d761983d22d9394c5f76037b30b45f547412f0",
+        "rev": "aac1e42dfbc273b04ada773845fd16210ba90e6a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,15 +14,6 @@
       crossNixpkgsFor = forAllSystems (system: import nixpkgs {
         inherit system;
         crossSystem = (nixpkgsFor.${system}).lib.systems.examples.mingwW64;
-        overlays = [
-          (self: super: {
-            # Waiting for https://github.com/NixOS/nixpkgs/pull/172144 to get merged
-            rhash = super.rhash.overrideAttrs (oldAttrs: rec {
-              configureFlags = oldAttrs.configureFlags ++ [ "--target=${super.stdenv.hostPlatform.config}" ];
-            });
-          })
-        ];
-
       });
     in
     {


### PR DESCRIPTION
The rhash patch has been merged into nixpkgs/master, and is no longer necessary. Merging this should speed up the CI, since cache.nixos.org will now have the patched version, and we don't need to build it ourselves. 