### PR TITLE
fixes to_char for older g++ (g++-10 in particular)

### DIFF
--- a/src/prettyprinter.cpp
+++ b/src/prettyprinter.cpp
@@ -680,7 +680,7 @@ void PrettyPrinter::exprFalse() { st.push_back("false"); }
 void PrettyPrinter::exprDouble(double d)
 {
     auto s = std::array<char, 60>{};
-#if defined(__GNUC__) && (__GNUC__ < 110000L)
+#if defined(__GNUC__) && (__GNUC__ < 11)
     // g++-10 does not have std::to_char(It,It,float/double), hence temporary workaround:
     if (60 <= std::snprintf(s.data(), 60, "%.52g", d))
         std::cerr << "Floating point number was truncated\n";

--- a/src/prettyprinter.cpp
+++ b/src/prettyprinter.cpp
@@ -680,13 +680,13 @@ void PrettyPrinter::exprFalse() { st.push_back("false"); }
 void PrettyPrinter::exprDouble(double d)
 {
     auto s = std::array<char, 60>{};
-#if (not defined(__GLIBCXX__) || (__GLIBCXX__ >= 20220519)) && not defined(_LIBCPP_VERSION)
-    // std=c++17, works with g++-11, but not with g++-10, which does not have to_chars for floats
-    if (auto [_, ec] = std::to_chars(s.begin(), s.end(), d, std::chars_format::general, 52); ec != std::errc{})
-        throw std::runtime_error{std::make_error_code(ec).message()};
-#else
+#if defined(__GNUC__) && (__GNUC__ < 110000L)
+    // g++-10 does not have std::to_char(It,It,float/double), hence temporary workaround:
     if (60 <= std::snprintf(s.data(), 60, "%.52g", d))
         std::cerr << "Floating point number was truncated\n";
+#else
+    if (auto [_, ec] = std::to_chars(s.begin(), s.end(), d, std::chars_format::general, 52); ec != std::errc{})
+        throw std::runtime_error{std::make_error_code(ec).message()};
 #endif
     st.emplace_back(s.data());
 }


### PR DESCRIPTION
github updated GLIBCXX on mac and the compatibility macro did not work as expected: the minor increment in compiler/library version resulted in radically newer library release date which still does not have `to_char` feature (and unlikely to have).
Therefore, rewrote the macro to check the compiler version in particular.