### PR TITLE
Fix template params

### DIFF
--- a/include/utap/position.h
+++ b/include/utap/position.h
@@ -37,8 +37,9 @@ namespace UTAP
         /** Start and end absolute offsets in the original source file.
          * Both INT_MAX indicate an unknown location, or outside the source file
          * (e.g. built-in, engine utility, or introduced by LSC translation) */
-        uint32_t start{std::numeric_limits<int32_t>::max()}, end{std::numeric_limits<int32_t>::max()};
+        static constexpr auto unknown_pos = std::numeric_limits<int32_t>::max();
         // Java Integer cannot parse UINT_MAX, thus use INT_MAX.
+        uint32_t start{unknown_pos}, end{unknown_pos};
         position_t() = default;
         position_t(uint32_t start, uint32_t end): start{start}, end{end} {}
     };

--- a/include/utap/signalflow.h
+++ b/include/utap/signalflow.h
@@ -166,7 +166,7 @@ namespace UTAP
      * similar to ostream_iterator except it does not print last delimiter.
      */
     template <class T>
-    struct print : public std::unary_function<T, void>
+    struct print
     {
         std::ostream& os;
         const std::string& infix;

--- a/include/utap/statement.h
+++ b/include/utap/statement.h
@@ -241,7 +241,7 @@ namespace UTAP
     class StatementVisitor
     {
     public:
-        virtual ~StatementVisitor() = default;
+        virtual ~StatementVisitor() noexcept = default;
         virtual int32_t visitEmptyStatement(EmptyStatement* stat) = 0;
         virtual int32_t visitExprStatement(ExprStatement* stat) = 0;
         virtual int32_t visitAssertStatement(AssertStatement* stat) = 0;

--- a/src/signalflow.cpp
+++ b/src/signalflow.cpp
@@ -980,7 +980,7 @@ inline void set_remove(SignalFlow::strset_t& from, const SignalFlow::strset_t& w
         from.erase(b);
 }
 
-struct surround : public std::unary_function<const char*, void>
+struct surround
 {
     std::ostream& out;
     std::string_view pre;

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -630,6 +630,16 @@ void TypeChecker::visitIODecl(iodecl_t& iodecl)
     }
 }
 
+bool isDefaultInt(type_t type)
+{
+    if (type.isIntegral()) {
+        auto range = type.getRange();
+        return (isConstantInteger(range.first) && isConstantInteger(range.second)) &&
+               range.first.getValue() == defaultIntMin && range.second.getValue() == defaultIntMax;
+    }
+    return false;
+}
+
 void TypeChecker::visitProcess(instance_t& process)
 {
     for (size_t i = 0; i < process.unbound; i++) {
@@ -638,7 +648,7 @@ void TypeChecker::visitProcess(instance_t& process)
          */
         symbol_t parameter = process.parameters[i];
         type_t type = parameter.getType();
-        if (!(type.isScalar() || type.isRange()) || type.is(REF)) {
+        if (!(type.isScalar() || type.isRange()) || type.is(REF) || isDefaultInt(type)) {
             handleError(type, "$Free_process_parameters_must_be_a_bounded_integer_or_a_scalar");
         }
 


### PR DESCRIPTION
- [x] some minor compilation issues
- [x] added error on `P(int id) = Template()` as `int` implies huge range, which is usually unintended, see https://github.com/UPPAALModelChecker/uppaal/issues/849