### PR TITLE
Added a negative test case to check that quantifier expressions are analyzed fully

### DIFF
--- a/test/test_typechecker.cpp
+++ b/test/test_typechecker.cpp
@@ -87,52 +87,98 @@ public:
     }
 };
 
-TEST_CASE("sum expression")
+TEST_SUITE("Quantifier sum")
 {
-    document_fixture f;
-    f.set_system_decls("int x = sum (index : int[0, 5]) index;");
-    auto document = f.parse();
+    TEST_CASE("sum expression")
+    {
+        document_fixture f;
+        f.set_system_decls("int x = sum (index : int[0, 5]) index;");
+        auto document = f.parse();
 
-    CHECK(document->getErrors().size() == 0);
-    CHECK(document->getWarnings().size() == 0);
+        CHECK(document->getErrors().size() == 0);
+        CHECK(document->getWarnings().size() == 0);
+    }
+
+    TEST_CASE("sum over array")
+    {
+        document_fixture f;
+        f.set_system_decls("int a[3] = {1,4,9};\nint x = sum(i : int[0, 2]) a[i];");
+        auto document = f.parse();
+        CHECK(document->getWarnings().size() == 0);
+        const auto errors = document->getErrors();
+        REQUIRE(errors.size() == 1);
+        CHECK(errors[0].msg == "$Must_be_computable_at_compile_time");
+    }
+
+    TEST_CASE("sum over const array")
+    {
+        document_fixture f;
+        f.set_system_decls("const int a[3] = {1,4,9};\nint x = sum(i : int[0, 2]) a[i];");
+        auto document = f.parse();
+        CHECK(document->getWarnings().size() == 0);
+        CHECK(document->getErrors().size() == 0);
+    }
 }
 
-TEST_CASE("sum over array")
+TEST_SUITE("Quantifier forall")
 {
-    document_fixture f;
-    f.set_system_decls("int a[3] = {1,4,9};\nint x = sum(i : int[0, 2]) a[i];");
-    auto document = f.parse();
-    CHECK(document->getWarnings().size() == 0);
-    const auto errors = document->getErrors();
-    REQUIRE(errors.size() == 1);
-    CHECK(errors[0].msg == "$Must_be_computable_at_compile_time");
+    TEST_CASE("forall expression")
+    {
+        document_fixture f;
+        f.set_system_decls("bool x = forall (index : int[0, 5]) index > 3;");
+        auto document = f.parse();
+
+        CHECK(document->getErrors().size() == 0);
+        CHECK(document->getWarnings().size() == 0);
+    }
+
+    TEST_CASE("forall over array")
+    {
+        document_fixture f;
+        f.set_system_decls("bool b[3]={1,1,1};\nbool x = forall(i : int[0,2]) b[i];");
+        auto document = f.parse();
+        CHECK(document->getWarnings().size() == 0);
+        const auto errors = document->getErrors();
+        REQUIRE(errors.size() == 1);
+        CHECK(errors[0].msg == "$Must_be_computable_at_compile_time");
+    }
+
+    TEST_CASE("forall over const array")
+    {
+        document_fixture f;
+        f.set_system_decls("const bool b[3]={1,1,1};\nbool x = forall(i : int[0,2]) b[i];");
+        auto document = f.parse();
+        CHECK(document->getWarnings().size() == 0);
+        CHECK(document->getErrors().size() == 0);
+    }
 }
 
-TEST_CASE("sum over const array")
+TEST_SUITE("Quantifier exists")
 {
-    document_fixture f;
-    f.set_system_decls("const int a[3] = {1,4,9};\nint x = sum(i : int[0, 2]) a[i];");
-    auto document = f.parse();
-    CHECK(document->getWarnings().size() == 0);
-    CHECK(document->getErrors().size() == 0);
-}
-
-TEST_CASE("forall expression")
-{
-    document_fixture f;
-    f.set_system_decls("bool x = forall (index : int[0, 5]) index > 3;");
-    auto document = f.parse();
-
-    CHECK(document->getErrors().size() == 0);
-    CHECK(document->getWarnings().size() == 0);
-}
-
-TEST_CASE("exists expression")
-{
-    document_fixture f;
-    f.set_system_decls("bool x = exists (index : int[0, 5]) index > 3;");
-    auto document = f.parse();
-
-    CHECK(document->getErrors().size() == 0);
-    CHECK(document->getWarnings().size() == 0);
+    TEST_CASE("exists expression")
+    {
+        document_fixture f;
+        f.set_system_decls("bool x = exists (index : int[0, 5]) index > 3;");
+        auto document = f.parse();
+        CHECK(document->getErrors().size() == 0);
+        CHECK(document->getWarnings().size() == 0);
+    }
+    TEST_CASE("exists over array")
+    {
+        document_fixture f;
+        f.set_system_decls("bool b[3]={0,0,1};\nbool x = exists(i : int[0,2]) b[i];");
+        auto document = f.parse();
+        CHECK(document->getWarnings().size() == 0);
+        const auto errors = document->getErrors();
+        REQUIRE(errors.size() == 1);
+        CHECK(errors[0].msg == "$Must_be_computable_at_compile_time");
+    }
+    TEST_CASE("exists over const array")
+    {
+        document_fixture f;
+        f.set_system_decls("const bool b[3]={0,0,1};\nbool x = exists(i : int[0,2]) b[i];");
+        auto document = f.parse();
+        CHECK(document->getWarnings().size() == 0);
+        CHECK(document->getErrors().size() == 0);
+    }
 }

--- a/test/test_typechecker.cpp
+++ b/test/test_typechecker.cpp
@@ -87,7 +87,7 @@ public:
     }
 };
 
-TEST_CASE("SUM expression")
+TEST_CASE("sum expression")
 {
     document_fixture f;
     f.set_system_decls("int x = sum (index : int[0, 5]) index;");
@@ -95,6 +95,26 @@ TEST_CASE("SUM expression")
 
     CHECK(document->getErrors().size() == 0);
     CHECK(document->getWarnings().size() == 0);
+}
+
+TEST_CASE("sum over array")
+{
+    document_fixture f;
+    f.set_system_decls("int a[3] = {1,4,9};\nint x = sum(i : int[0, 2]) a[i];");
+    auto document = f.parse();
+    CHECK(document->getWarnings().size() == 0);
+    const auto errors = document->getErrors();
+    REQUIRE(errors.size() == 1);
+    CHECK(errors[0].msg == "$Must_be_computable_at_compile_time");
+}
+
+TEST_CASE("sum over const array")
+{
+    document_fixture f;
+    f.set_system_decls("const int a[3] = {1,4,9};\nint x = sum(i : int[0, 2]) a[i];");
+    auto document = f.parse();
+    CHECK(document->getWarnings().size() == 0);
+    CHECK(document->getErrors().size() == 0);
 }
 
 TEST_CASE("forall expression")


### PR DESCRIPTION
The following fails with error:
```c
int a[3] = {1,4,9};
int x = sum(i : int[0, 2]) a[i];
```
The following succeeds without errors:
```c
const int a[3] = {1,4,9};
int x = sum(i : int[0, 2]) a[i];
```
