### PR TITLE
Revert "Symbolic feature: allow assigning doubles to clocks"

### DIFF
--- a/src/featurechecker.cpp
+++ b/src/featurechecker.cpp
@@ -61,7 +61,7 @@ void FeatureChecker::visitAssignment(expression_t& ass)
 {
     switch (ass.getKind()) {
     case Constants::ASSIGN:
-        if (ass.usesFP() && !ass.usesHybrid() && !ass.get(0).getType().isClock())
+        if (ass.usesFP() && !ass.usesHybrid())
             supportedMethods.symbolic = false;
         break;
     case Constants::COMMA:

--- a/test/test_featurechecker.cpp
+++ b/test/test_featurechecker.cpp
@@ -131,7 +131,7 @@ TEST_CASE("Hybrid and normal clock update")
     auto document = std::make_unique<UTAP::Document>();
     parseXMLBuffer(read_content("update_hybrid_and_normal_clock.xml").c_str(), document.get(), true);
     UTAP::FeatureChecker checker(*document);
-    CHECK(checker.getSupportedMethods().symbolic);
+    CHECK(!checker.getSupportedMethods().symbolic);
     CHECK(checker.getSupportedMethods().stochastic);
 }
 


### PR DESCRIPTION
Reverts UPPAALModelChecker/utap#27

The feature that the original change supported has been killed. Thus we should strengthen checks again