### PR TITLE
Allow automatic deduction of goal expression in learning queries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Get clang-format-11
+      run: |
+          sudo apt-get -q -y update
+          sudo apt-get -q -y install clang-format-11
     - name: Format
-      run: find src include test -iregex '.*\.\(c\|h\|cpp\|hpp\|cc\|hh\|cxx\|hxx\)$' | xargs clang-format -n -Werror
+      run: find src include test -iregex '.*\.\(c\|h\|cpp\|hpp\|cc\|hh\|cxx\|hxx\)$' | xargs clang-format-11 -n -Werror
 #  build-nix:
 #    runs-on: ubuntu-latest
 #    steps:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.idea
 /result
 /libs
+/.vscode

--- a/include/utap/AbstractBuilder.hpp
+++ b/include/utap/AbstractBuilder.hpp
@@ -217,7 +217,7 @@ namespace UTAP
         void exprBuiltinFunction1(Constants::kind_t) override;
         void exprBuiltinFunction2(Constants::kind_t) override;
         void exprBuiltinFunction3(Constants::kind_t) override;
-        void exprMinMaxExp(Constants::kind_t, PRICETYPE, Constants::kind_t) override;
+        void exprMinMaxExp(Constants::kind_t, PRICETYPE) override;
         void exprLoadStrategy() override;
         void exprSaveStrategy() override;
 

--- a/include/utap/ExpressionBuilder.hpp
+++ b/include/utap/ExpressionBuilder.hpp
@@ -191,7 +191,7 @@ namespace UTAP
         void exprBuiltinFunction1(Constants::kind_t) override;
         void exprBuiltinFunction2(Constants::kind_t) override;
         void exprBuiltinFunction3(Constants::kind_t) override;
-        void exprMinMaxExp(Constants::kind_t, PRICETYPE, Constants::kind_t) override;
+        void exprMinMaxExp(Constants::kind_t, PRICETYPE) override;
         void exprSaveStrategy() override;
         void exprLoadStrategy() override;
 

--- a/include/utap/builder.h
+++ b/include/utap/builder.h
@@ -356,8 +356,8 @@ namespace UTAP
         virtual void exprBuiltinFunction2(Constants::kind_t) = 0;
         virtual void exprBuiltinFunction3(Constants::kind_t) = 0;
 
-        enum PRICETYPE { TIMEPRICE, EXPRPRICE, PROBAPRICE };
-        virtual void exprMinMaxExp(Constants::kind_t, PRICETYPE, Constants::kind_t) = 0;
+        enum PRICETYPE { TIMEPRICE, EXPRPRICE };
+        virtual void exprMinMaxExp(Constants::kind_t, PRICETYPE) = 0;
         virtual void exprLoadStrategy() = 0;
         virtual void exprSaveStrategy() = 0;
 

--- a/src/ExpressionBuilder.cpp
+++ b/src/ExpressionBuilder.cpp
@@ -675,42 +675,34 @@ void ExpressionBuilder::exprProbaQualitative(Constants::kind_t pathType, Constan
         std::move(args), position));
 }
 
-void ExpressionBuilder::exprMinMaxExp(Constants::kind_t kind, PRICETYPE ptype, Constants::kind_t quant)
+void ExpressionBuilder::exprMinMaxExp(Constants::kind_t kind, PRICETYPE ptype)
 {
-    if (quant != Constants::DIAMOND) {
-        handleError(TypeException{"$Wrong_path_quantifier"});
-    }
+    auto boundVar = fragments[3];
+    auto bound = fragments[2];
+    auto discrete = fragments[1];
+    auto cont = fragments[0];
 
-    auto boundVar = fragments[4];
-    auto bound = fragments[3];
-    auto discrete = fragments[2];
-    auto cont = fragments[1];
-
-    if (!discrete.isTrue() && !cont.isTrue()) {
+    if (!discrete.isTrue() || !cont.isTrue()) {
         discrete.setType(type_t::createPrimitive(LIST, position));
         cont.setType(type_t::createPrimitive(LIST, position));
     }
-    auto& control = fragments[0];
     expression_t price;
     expression_t level = makeConstant(0);
-    size_t nb = 5;
+    size_t nb = 4;
     switch (ptype) {
     case TIMEPRICE:  // use time
         price = makeConstant(1);
         break;
     case EXPRPRICE:  // user-provided expression
-        price = fragments[5];
+        price = fragments[4];
         ++nb;
-        break;
-    case PROBAPRICE:  // use boolean expression
-        price = control;
         break;
     default: handleError(TypeException{"$Unknown_price_type"});
     }
 
     assert(nb <= fragments.size());
 
-    auto args = std::vector<expression_t>{boundVar, bound, control, price, level, discrete, cont};
+    auto args = std::vector<expression_t>{boundVar, bound, price, level, discrete, cont};
     fragments.pop(nb);
     fragments.push(expression_t::createNary(kind, std::move(args), position));
 }

--- a/src/abstractbuilder.cpp
+++ b/src/abstractbuilder.cpp
@@ -389,7 +389,7 @@ void AbstractBuilder::exprBuiltinFunction3(Constants::kind_t)
     throw NotSupportedException("exprBuiltinFunction3 is not supported");
 }
 
-void AbstractBuilder::exprMinMaxExp(Constants::kind_t, PRICETYPE, Constants::kind_t)
+void AbstractBuilder::exprMinMaxExp(Constants::kind_t, PRICETYPE)
 {
     throw NotSupportedException("exprMinMaxExp is not supported");
 }

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -471,7 +471,7 @@ size_t expression_t::getSize() const
     case PROBAMINDIAMOND: assert(data->sub.size() == 5); return 5;
 
     case MIN_EXP:
-    case MAX_EXP: return 7;
+    case MAX_EXP: assert(data->sub.size() == 6); return 6;
 
     case PROBAEXP: assert(data->sub.size() == 5); return 5;
 

--- a/src/parser.y
+++ b/src/parser.y
@@ -283,7 +283,7 @@ const char* utap_msg(const char *msg)
 %token T_DYNAMIC T_HYBRID
 %token T_SPAWN T_EXIT T_NUMOF
 
-%type <kind> ExpQuantifier ExpPrQuantifier
+%type <kind> ExpQuantifier
 %type <kind> PathType
 %type <number> ArgList FieldDeclList FieldDeclIdList FieldDecl
 %type <number> ParameterList FieldInitList
@@ -1690,10 +1690,6 @@ OldGuardList:
 ExpQuantifier:
          T_MINEXP { $$ = MIN_EXP;} 
          | T_MAXEXP { $$ = MAX_EXP;};
-         
-ExpPrQuantifier:
-         T_MINPR { $$ = MIN_EXP;} 
-         | T_MAXPR { $$ = MAX_EXP;};
         
 SubjectionList: // do not allow multiple subjections for the time being
         /*Id ',' SubjectionList {
@@ -1792,19 +1788,15 @@ AssignablePropperty:
         CALL(@1, @4, exprBinary(PO_CONTROL));
 	CALL(@1, @4, property());
     }
-    | ExpQuantifier '(' Expression ')' '[' BoundType ']' Features ':' PathType Expression Subjection Imitation
+    | ExpQuantifier '(' Expression ')' '[' BoundType ']' Features  Subjection Imitation
     {
-        CALL(@1, @12, exprMinMaxExp($1,  ParserBuilder::EXPRPRICE, $10));
-	CALL(@1, @12, property());
-    }
-    | ExpQuantifier '[' BoundType ']' Features ':' PathType Expression Subjection Imitation
-    {
-        CALL(@1, @8, exprMinMaxExp($1, ParserBuilder::TIMEPRICE, $7));
+        CALL(@1, @9, exprMinMaxExp($1,  ParserBuilder::EXPRPRICE));
 	CALL(@1, @9, property());
     }
-    | ExpPrQuantifier '[' BoundType ']' Features ':' PathType Expression Subjection Imitation {
-        CALL(@1, @8, exprMinMaxExp($1, ParserBuilder::PROBAPRICE, $7));
-	CALL(@1, @9, property());
+    | ExpQuantifier '[' BoundType ']' Features Subjection Imitation
+    {
+        CALL(@1, @6, exprMinMaxExp($1, ParserBuilder::TIMEPRICE));
+	CALL(@1, @6, property());
     }
     | T_LOAD_STRAT Features '(' Expression ')' {
         CALL(@1, @5, exprLoadStrategy());

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -2357,7 +2357,7 @@ bool TypeChecker::checkExpression(expression_t expr)
                 return false;
             }
         }
-        
+
         type = type_t::createPrimitive(FORMULA);
         break;
     case SMC_CONTROL:

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -2340,7 +2340,7 @@ bool TypeChecker::checkExpression(expression_t expr)
         break;
     case MIN_EXP:
     case MAX_EXP:
-        // 0 = bound clock, 1 = boundvar, 2 = path, 3 = price
+        // 0 = bound clock, 1 = boundvar, 2 = price
         if (!isConstantInteger(expr[0]) && !isClock(expr[0])) {
             handleError(expr[0], "$Clock_expected");
             ok = false;
@@ -2351,15 +2351,14 @@ bool TypeChecker::checkExpression(expression_t expr)
         }
         if (!ok)
             return false;
-        if (isFormula(expr[2])) {
-            type = type_t::createPrimitive(FORMULA);
-        }
-        for (size_t i = 3; i < expr.getSize(); ++i) {
+        for (size_t i = 2; i < expr.getSize(); ++i) {
             if (expr[i].changesAnyVariable()) {
                 handleError(expr[i], "$Property_must_be_side-effect_free");
                 return false;
             }
         }
+        
+        type = type_t::createPrimitive(FORMULA);
         break;
     case SMC_CONTROL:
         if (expr.getSize() == 3) {

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -15,8 +15,8 @@
  */
 
 #include "utap/StatementBuilder.hpp"
-#include "utap/utap.h"
 #include "utap/typechecker.h"
+#include "utap/utap.h"
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
@@ -80,9 +80,7 @@ public:
         query = fragments[0];
         fragments.pop();
     }
-    void typecheck(){
-        checker.checkExpression(query);
-    }
+    void typecheck() { checker.checkExpression(query); }
     [[nodiscard]] UTAP::expression_t getQuery() const { return query; }
     UTAP::variable_t* addVariable(UTAP::type_t type, const std::string& name, UTAP::expression_t init,
                                   UTAP::position_t pos) override


### PR DESCRIPTION
Learning queries can now be shortened:
`minE(cost)[c<=10]:<> c<=10`
to
`minE(cost)[c<=10]`

The deduction also works with global time constraints
`minE(cost)[<=20] :<> time<=20` where `time` is a clock used as a timer
to
`minE(cost)[<=20]`

This PR is not backwards compatible!