### PR TITLE
Feature check on clock initializers and only on instanced templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.idea
 /result
 /libs
+/.vscode

--- a/include/utap/document.h
+++ b/include/utap/document.h
@@ -366,6 +366,7 @@ namespace UTAP
         std::deque<edge_t> edges;               /**< Edges */
         std::vector<expression_t> dynamicEvals;
         bool isTA;
+        bool isInstanced{false};
 
         int addDynamicEval(expression_t t)
         {

--- a/include/utap/document.h
+++ b/include/utap/document.h
@@ -366,7 +366,7 @@ namespace UTAP
         std::deque<edge_t> edges;               /**< Edges */
         std::vector<expression_t> dynamicEvals;
         bool isTA;
-        bool isInstanced{false};
+        bool isInstanced{false}; /**< Is the template used in the system*/
 
         int addDynamicEval(expression_t t)
         {

--- a/include/utap/featurechecker.h
+++ b/include/utap/featurechecker.h
@@ -42,6 +42,7 @@ namespace UTAP
         void visitGuard(expression_t& guard);
         void visitLocation(location_t& state) override;
         void visitVariable(variable_t&) override;
+        bool visitTemplateBefore(template_t&) override;
 
         void visitFrame(const frame_t& frame);
         bool isRateDisallowedInSymbolic(const expression_t& e);

--- a/include/utap/featurechecker.h
+++ b/include/utap/featurechecker.h
@@ -41,6 +41,7 @@ namespace UTAP
         void visitAssignment(expression_t& ass);
         void visitGuard(expression_t& guard);
         void visitLocation(location_t& state) override;
+        void visitVariable(variable_t&) override;
 
         void visitFrame(const frame_t& frame);
         bool isRateDisallowedInSymbolic(const expression_t& e);

--- a/include/utap/symbols.h
+++ b/include/utap/symbols.h
@@ -23,9 +23,9 @@
 #ifndef UTAP_SYMBOLS_HH
 #define UTAP_SYMBOLS_HH
 
-#include "utap/common.h"
-#include "utap/position.h"
-#include "utap/type.h"
+#include "common.h"
+#include "position.h"
+#include "type.h"
 
 #include <exception>
 #include <cstdint>

--- a/src/DocumentBuilder.cpp
+++ b/src/DocumentBuilder.cpp
@@ -404,7 +404,9 @@ void DocumentBuilder::process(const char* name)
     if (type.size() > 0) {
         // FIXME: Check type of unbound parameters
     }
-    document.addProcess(*static_cast<instance_t*>(symbol.getData()), position);
+    auto& instance = *static_cast<instance_t*>(symbol.getData());
+    instance.templ->isInstanced = true;
+    document.addProcess(instance, position);
     procPriority(name);
 }
 

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -24,7 +24,6 @@
 #include "utap/builder.h"
 #include "utap/statement.h"
 
-#include <functional>  // std::bind
 #include <sstream>
 #include <stack>
 #include <cassert>
@@ -39,7 +38,6 @@
 using namespace UTAP;
 using namespace Constants;
 
-using std::bind;
 using std::list;
 using std::stack;
 using std::vector;
@@ -52,8 +50,6 @@ using std::set;
 using std::string;
 using std::ostream;
 using std::deque;
-
-using namespace std::placeholders;  // _1, _2, etc for std::bind
 
 static const char* const unsupported = "Internal error: Feature not supported in this mode.";
 static const char* const invalid_type = "$Invalid_type";

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -24,10 +24,10 @@
 #include "utap/builder.h"
 #include "utap/statement.h"
 
+#include <functional>  // std::mem_fn
 #include <sstream>
 #include <stack>
 #include <cassert>
-#include <cstring>
 
 #ifdef __MINGW32__
 #include <windows.h>

--- a/src/featurechecker.cpp
+++ b/src/featurechecker.cpp
@@ -38,6 +38,12 @@ FeatureChecker::FeatureChecker(Document& document)
         supportedMethods.symbolic = false;
 }
 
+bool FeatureChecker::visitTemplateBefore(template_t& templ)
+{
+    // Only check features if template is actually used in the system
+    return templ.isInstanced;
+}
+
 void FeatureChecker::visitVariable(variable_t& var)
 {
     if (var.uid.getType().isClock() && !var.init.empty() && var.init.usesFP())

--- a/src/featurechecker.cpp
+++ b/src/featurechecker.cpp
@@ -25,7 +25,6 @@
 #include "utap/common.h"
 #include "utap/document.h"
 
-#include <algorithm>
 #include <cassert>
 
 using namespace UTAP;

--- a/src/featurechecker.cpp
+++ b/src/featurechecker.cpp
@@ -25,6 +25,7 @@
 #include "utap/common.h"
 #include "utap/document.h"
 
+#include <algorithm>
 #include <cassert>
 
 using namespace UTAP;
@@ -34,6 +35,12 @@ FeatureChecker::FeatureChecker(Document& document)
     document.accept(*this);
     visitFrame(document.getGlobals().frame);
     if (document.hasDynamicTemplates())
+        supportedMethods.symbolic = false;
+}
+
+void FeatureChecker::visitVariable(variable_t& var)
+{
+    if (var.uid.getType().isClock() && !var.init.empty() && var.init.usesFP())
         supportedMethods.symbolic = false;
 }
 

--- a/test/document_fixture.h
+++ b/test/document_fixture.h
@@ -1,12 +1,12 @@
 #ifndef INCLUDE_UTAP_DOCUMENT_FIXTURE_HPP
 #define INCLUDE_UTAP_DOCUMENT_FIXTURE_HPP
 
-#include "utap/utap.h"
-
 #include <memory>
 #include <stdexcept>
 #include <string>
 #include <cstring>
+
+#include <utap/utap.h>
 
 class document_fixture
 {

--- a/test/document_fixture.h
+++ b/test/document_fixture.h
@@ -1,0 +1,70 @@
+#ifndef INCLUDE_UTAP_DOCUMENT_FIXTURE_HPP
+#define INCLUDE_UTAP_DOCUMENT_FIXTURE_HPP
+
+#include "utap/utap.h"
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <cstring>
+
+class document_fixture
+{
+    std::string decls{};
+    std::string template_decls{};
+    std::string sys_decls{};
+
+    template <typename... Args>
+    std::string string_format(const std::string& format, Args... args) const
+    {
+        using namespace std::string_literals;
+        auto size = std::snprintf(nullptr, 0, format.c_str(), args...);
+        if (size <= 0)
+            throw std::logic_error("Failed to format: "s + std::strerror(errno));
+        auto res = std::string(size, ' ');
+        if (auto s = std::snprintf(&res[0], size + 1, format.c_str(), args...); s != size)
+            throw std::logic_error("Failed to format: "s + std::strerror(errno));
+        return res;
+    }
+
+public:
+    void set_decls(std::string text) { decls = std::move(text); }
+    void set_template_decls(std::string text) { template_decls = std::move(text); }
+    void set_system_decls(std::string text) { sys_decls = std::move(text); }
+
+    [[nodiscard]] std::unique_ptr<UTAP::Document> parse() const
+    {
+        std::string data = string_format(system_template, decls.c_str(), template_decls.c_str(), sys_decls.c_str());
+        auto document = std::make_unique<UTAP::Document>();
+        parseXMLBuffer(data.c_str(), document.get(), true);
+        return document;
+    }
+
+private:
+    static constexpr const char* system_template = R"XML(<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE nta PUBLIC '-//Uppaal Team//DTD Flat System 1.5//EN' 'http://www.it.uu.se/research/group/darts/uppaal/flat-1_5.dtd'>
+<nta>
+    <declaration>%s</declaration>
+    <template>
+        <name x="5" y="5">Template</name>
+        <declaration>%s</declaration>
+        <location id="id0" x="0" y="0">
+        </location>
+        <init ref="id0"/>
+    </template>
+    <system>
+%s
+Process = Template();
+system Process;
+    </system>
+    <queries>
+        <query>
+            <formula/>
+            <comment/>
+        </query>
+    </queries>
+</nta>
+)XML";
+};
+
+#endif

--- a/test/test_featurechecker.cpp
+++ b/test/test_featurechecker.cpp
@@ -19,6 +19,8 @@
    USA
 */
 
+#include "document_fixture.h"
+
 #include "utap/featurechecker.h"
 #include "utap/utap.h"
 
@@ -141,5 +143,48 @@ TEST_CASE("Double comparison")
     parseXMLBuffer(read_content("double_compare.xml").c_str(), document.get(), true);
     UTAP::FeatureChecker checker(*document);
     CHECK(!checker.getSupportedMethods().symbolic);
+    CHECK(checker.getSupportedMethods().stochastic);
+}
+
+TEST_CASE("Empty document")
+{
+    auto f = document_fixture{};
+    auto document = f.parse();
+
+    UTAP::FeatureChecker checker(*document);
+    CHECK(checker.getSupportedMethods().symbolic);
+    CHECK(checker.getSupportedMethods().stochastic);
+}
+
+TEST_CASE("Clock floating point initializer")
+{
+    auto f = document_fixture{};
+    f.set_decls("clock c = 2.5;");
+    auto document = f.parse();
+
+    UTAP::FeatureChecker checker(*document);
+    CHECK(!checker.getSupportedMethods().symbolic);
+    CHECK(checker.getSupportedMethods().stochastic);
+}
+
+TEST_CASE("Clock integer initializer")
+{
+    auto f = document_fixture{};
+    f.set_decls("clock c = 2;");
+    auto document = f.parse();
+
+    UTAP::FeatureChecker checker(*document);
+    CHECK(checker.getSupportedMethods().symbolic);
+    CHECK(checker.getSupportedMethods().stochastic);
+}
+
+TEST_CASE("Clock uninitialized")
+{
+    auto f = document_fixture{};
+    f.set_decls("clock c;");
+    auto document = f.parse();
+
+    UTAP::FeatureChecker checker(*document);
+    CHECK(checker.getSupportedMethods().symbolic);
     CHECK(checker.getSupportedMethods().stochastic);
 }

--- a/test/test_typechecker.cpp
+++ b/test/test_typechecker.cpp
@@ -19,73 +19,12 @@
    USA
 */
 
-#include "utap/typechecker.h"
-#include "utap/utap.h"
+#include "document_fixture.h"
 
-#include <memory>
-#include <stdexcept>
-#include <string>
+#include "utap/typechecker.h"
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
-
-static constexpr const char* system_template = R"XML(<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE nta PUBLIC '-//Uppaal Team//DTD Flat System 1.5//EN' 'http://www.it.uu.se/research/group/darts/uppaal/flat-1_5.dtd'>
-<nta>
-	<declaration>%s</declaration>
-	<template>
-		<name x="5" y="5">Template</name>
-		<declaration>%s</declaration>
-		<location id="id0" x="0" y="0">
-		</location>
-		<init ref="id0"/>
-	</template>
-	<system>
-%s
-Process = Template();
-system Process;
-    </system>
-	<queries>
-		<query>
-			<formula/>
-			<comment/>
-		</query>
-	</queries>
-</nta>
-)XML";
-
-class document_fixture
-{
-    std::string decls{};
-    std::string template_decls{};
-    std::string sys_decls{};
-
-    template <typename... Args>
-    std::string string_format(const std::string& format, Args... args) const
-    {
-        using namespace std::string_literals;
-        auto size = std::snprintf(nullptr, 0, format.c_str(), args...);
-        if (size <= 0)
-            throw std::logic_error("Failed to format: "s + std::strerror(errno));
-        auto res = std::string(size, ' ');
-        if (auto s = std::snprintf(&res[0], size + 1, format.c_str(), args...); s != size)
-            throw std::logic_error("Failed to format: "s + std::strerror(errno));
-        return res;
-    }
-
-public:
-    void set_decls(std::string text) { decls = std::move(text); }
-    void set_template_decls(std::string text) { template_decls = std::move(text); }
-    void set_system_decls(std::string text) { sys_decls = std::move(text); }
-
-    [[nodiscard]] std::unique_ptr<UTAP::Document> parse() const
-    {
-        std::string data = string_format(system_template, decls.c_str(), template_decls.c_str(), sys_decls.c_str());
-        auto document = std::make_unique<UTAP::Document>();
-        parseXMLBuffer(data.c_str(), document.get(), true);
-        return document;
-    }
-};
 
 TEST_SUITE("Quantifier sum")
 {


### PR DESCRIPTION
We can also implement floating point initializers as a warning instead.