### PR TITLE
Removed unnessecary xpath duplication in line_t

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.idea
 /result
 /libs
+/.vscode

--- a/include/utap/ExpressionBuilder.hpp
+++ b/include/utap/ExpressionBuilder.hpp
@@ -135,7 +135,7 @@ namespace UTAP
         explicit ExpressionBuilder(Document& doc);
         ExpressionFragments& getExpressions();
 
-        void addPosition(uint32_t position, uint32_t offset, uint32_t line, const std::string& path) override;
+        void addPosition(uint32_t position, uint32_t offset, uint32_t line, std::shared_ptr<std::string> path) override;
 
         void handleError(const TypeException&) override;
         void handleWarning(const TypeException&) override;

--- a/include/utap/builder.h
+++ b/include/utap/builder.h
@@ -25,6 +25,7 @@
 
 #include "utap/common.h"
 
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -99,7 +100,8 @@ namespace UTAP
          * Add mapping from an absolute position to a relative XML
          * element.
          */
-        virtual void addPosition(uint32_t position, uint32_t offset, uint32_t line, const std::string& path) = 0;
+        virtual void addPosition(uint32_t position, uint32_t offset, uint32_t line,
+                                 std::shared_ptr<std::string> path) = 0;
 
         /**
          * Sets the current position. The current position indicates

--- a/include/utap/document.h
+++ b/include/utap/document.h
@@ -536,7 +536,7 @@ namespace UTAP
         /** Returns the queries enclosed in the model. */
         queries_t& getQueries();
 
-        void addPosition(uint32_t position, uint32_t offset, uint32_t line, const std::string& path);
+        void addPosition(uint32_t position, uint32_t offset, uint32_t line, std::shared_ptr<std::string> path);
         const Positions::line_t& findPosition(uint32_t position) const;
 
         variable_t* addVariableToFunction(function_t*, frame_t, type_t, const std::string&, expression_t initital,

--- a/include/utap/position.h
+++ b/include/utap/position.h
@@ -75,8 +75,6 @@ namespace UTAP
             line_t(uint32_t position, uint32_t offset, uint32_t line, std::shared_ptr<std::string> path):
                 position(position), offset(offset), line(line), path{std::move(path)}
             {}
-
-            const std::string& xpath() const { return *path; }
         };
 
     private:

--- a/include/utap/position.h
+++ b/include/utap/position.h
@@ -25,6 +25,7 @@
 
 #include <iosfwd>
 #include <limits>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -70,10 +71,12 @@ namespace UTAP
             uint32_t position;
             uint32_t offset;
             uint32_t line;
-            std::string path;
-            line_t(uint32_t position, uint32_t offset, uint32_t line, std::string path):
+            std::shared_ptr<std::string> path;
+            line_t(uint32_t position, uint32_t offset, uint32_t line, std::shared_ptr<std::string> path):
                 position(position), offset(offset), line(line), path{std::move(path)}
             {}
+
+            const std::string& xpath() const { return *path; }
         };
 
     private:
@@ -82,7 +85,7 @@ namespace UTAP
 
     public:
         /** Add information about a line to the container. */
-        void add(uint32_t position, uint32_t offset, uint32_t line, std::string path);
+        void add(uint32_t position, uint32_t offset, uint32_t line, std::shared_ptr<std::string> path);
 
         /**
          * Retrieves information about the line containing the given

--- a/include/utap/prettyprinter.h
+++ b/include/utap/prettyprinter.h
@@ -56,7 +56,7 @@ namespace UTAP
     public:
         PrettyPrinter(std::ostream& stream);
 
-        void addPosition(uint32_t position, uint32_t offset, uint32_t line, const std::string& path) override;
+        void addPosition(uint32_t position, uint32_t offset, uint32_t line, std::shared_ptr<std::string> path) override;
 
         void handleError(const TypeException&) override;
         void handleWarning(const TypeException&) override;

--- a/src/ExpressionBuilder.cpp
+++ b/src/ExpressionBuilder.cpp
@@ -59,7 +59,7 @@ ExpressionBuilder::ExpressionBuilder(Document& doc): document{doc}
 void ExpressionBuilder::addPosition(uint32_t position, uint32_t offset, uint32_t line,
                                     std::shared_ptr<std::string> path)
 {
-    document.addPosition(position, offset, line, path);
+    document.addPosition(position, offset, line, std::move(path));
 }
 
 void ExpressionBuilder::handleError(const TypeException& ex) { document.addError(position, ex.what()); }

--- a/src/ExpressionBuilder.cpp
+++ b/src/ExpressionBuilder.cpp
@@ -56,7 +56,8 @@ ExpressionBuilder::ExpressionBuilder(Document& doc): document{doc}
     scalar_count = 0;
 }
 
-void ExpressionBuilder::addPosition(uint32_t position, uint32_t offset, uint32_t line, const std::string& path)
+void ExpressionBuilder::addPosition(uint32_t position, uint32_t offset, uint32_t line,
+                                    std::shared_ptr<std::string> path)
 {
     document.addPosition(position, offset, line, path);
 }

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -1080,7 +1080,7 @@ void Document::recordStrictLowerBoundOnControllableEdges() { hasStrictLowControl
 
 void Document::addPosition(uint32_t position, uint32_t offset, uint32_t line, std::shared_ptr<std::string> path)
 {
-    positions.add(position, offset, line, path);
+    positions.add(position, offset, line, std::move(path));
 }
 
 const Positions::line_t& Document::findPosition(uint32_t position) const { return positions.find(position); }

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -1078,7 +1078,7 @@ bool Document::hasStrictLowerBoundOnControllableEdges() const { return hasStrict
 
 void Document::recordStrictLowerBoundOnControllableEdges() { hasStrictLowControlledGuards = true; }
 
-void Document::addPosition(uint32_t position, uint32_t offset, uint32_t line, const std::string& path)
+void Document::addPosition(uint32_t position, uint32_t offset, uint32_t line, std::shared_ptr<std::string> path)
 {
     positions.add(position, offset, line, path);
 }

--- a/src/libparser.h
+++ b/src/libparser.h
@@ -66,7 +66,7 @@ namespace UTAP
         uint32_t line;
         uint32_t offset;
         uint32_t position;
-        std::string path;
+        std::shared_ptr<std::string> path;
 
         /**
          * Sets the current path to \a s, offset to 0 and line to 1.
@@ -85,7 +85,7 @@ namespace UTAP
             // subtract 1 before calling Positions::find().
             line = 1;
             offset = 0;
-            path = s;
+            path = std::make_shared<std::string>(s);
             ++position;
             parser->addPosition(position, offset, line, path);
         }

--- a/src/libparser.h
+++ b/src/libparser.h
@@ -91,6 +91,18 @@ namespace UTAP
         }
 
         /**
+         * This overload provides a way reuse paths over multiple setPath calls
+         */
+        void setPath(UTAP::ParserBuilder* parser, std::shared_ptr<std::string> s)
+        {
+            line = 1;
+            offset = 0;
+            path = std::move(s);
+            ++position;
+            parser->addPosition(position, offset, line, path);
+        }
+
+        /**
          * Sets the position of \a builder to [position, position + n)
          * and increments position and offset by \a n.
          */

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -30,7 +30,7 @@ using std::vector;
 
 using namespace UTAP;
 
-void Positions::add(uint32_t position, uint32_t offset, uint32_t line, string path)
+void Positions::add(uint32_t position, uint32_t offset, uint32_t line, std::shared_ptr<string> path)
 {
     if (!elements.empty() && position < elements.back().position) {
         throw std::logic_error("Positions must be monotonically increasing");
@@ -70,7 +70,7 @@ void Positions::dump()
 
 std::ostream& operator<<(std::ostream& out, const UTAP::error_t& e)
 {
-    if (e.start.path.empty()) {
+    if (e.start.xpath().empty()) {
         out << e.msg << " at line " << e.start.line << " column " << (e.position.start - e.start.position)
             << " to line " << e.end.line << " column " << (e.position.end - e.end.position);
     } else {
@@ -85,12 +85,12 @@ std::string UTAP::error_t::str() const
 {
     if (position.start < start.position || position.end < end.position)
         return msg + " (Unknown position in document)";
-    if (start.path.empty()) {
+    if (start.xpath().empty()) {
         return msg + " at line " + std::to_string(start.line) + " column " +
                std::to_string(position.start - start.position) + " to line " + std::to_string(end.line) + " column " +
                std::to_string(position.end - end.position);
     } else {
-        return msg + " in " + start.path + " at line " + std::to_string(start.line) + " column " +
+        return msg + " in " + start.xpath() + " at line " + std::to_string(start.line) + " column " +
                std::to_string(position.start - start.position) + " to line " + std::to_string(end.line) + " column " +
                std::to_string(position.end - end.position);
     }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -70,7 +70,7 @@ void Positions::dump()
 
 std::ostream& operator<<(std::ostream& out, const UTAP::error_t& e)
 {
-    if (e.start.xpath().empty()) {
+    if (!e.start.path || e.start.path->empty()) {
         out << e.msg << " at line " << e.start.line << " column " << (e.position.start - e.start.position)
             << " to line " << e.end.line << " column " << (e.position.end - e.end.position);
     } else {
@@ -85,12 +85,12 @@ std::string UTAP::error_t::str() const
 {
     if (position.start < start.position || position.end < end.position)
         return msg + " (Unknown position in document)";
-    if (start.xpath().empty()) {
+    if (!start.path || start.path->empty()) {
         return msg + " at line " + std::to_string(start.line) + " column " +
                std::to_string(position.start - start.position) + " to line " + std::to_string(end.line) + " column " +
                std::to_string(position.end - end.position);
     } else {
-        return msg + " in " + start.xpath() + " at line " + std::to_string(start.line) + " column " +
+        return msg + " in " + *start.path + " at line " + std::to_string(start.line) + " column " +
                std::to_string(position.start - start.position) + " to line " + std::to_string(end.line) + " column " +
                std::to_string(position.end - end.position);
     }

--- a/src/prettyprinter.cpp
+++ b/src/prettyprinter.cpp
@@ -66,7 +66,7 @@ PrettyPrinter::PrettyPrinter(ostream& stream)
     select = guard = sync = update = probability = -1;
 }
 
-void PrettyPrinter::addPosition(uint32_t position, uint32_t offset, uint32_t line, const std::string& path) {}
+void PrettyPrinter::addPosition(uint32_t position, uint32_t offset, uint32_t line, std::shared_ptr<std::string> path) {}
 
 void PrettyPrinter::handleError(const TypeException& msg) { throw msg; }
 

--- a/src/xmlreader.cpp
+++ b/src/xmlreader.cpp
@@ -1090,7 +1090,7 @@ namespace UTAP
     bool XMLReader::templ()
     {
         if (begin(tag_t::TEMPLATE)) {
-            std::string t_path = path.get(tag_t::TEMPLATE);
+            auto t_path = std::make_shared<std::string>(path.get(tag_t::TEMPLATE));
             read();
             try {
                 /* Get the name and the parameters of the template. */


### PR DESCRIPTION
Small memory optimization


This optimization is effectively redundant there is almost no noticeable effect on a mid sized model:
![image](https://user-images.githubusercontent.com/10059450/212864398-e87365f5-8a72-4fa2-8053-9ce62209d2b5.png)

We only see a benefit with extreme cases (~21000 lines of code)
![image](https://user-images.githubusercontent.com/10059450/212863947-defd135a-7aae-4c10-b74c-281b98f34ac7.png)