### PR TITLE
Fix double free for lsc models during parsing

### DIFF
--- a/include/utap/document.h
+++ b/include/utap/document.h
@@ -202,11 +202,11 @@ struct instance_line_t;  // to be defined later
 /** Common members among LSC elements */
 struct LSC_element_t
 {
-    int nr{-1}; /**< Placement in input file */
+    uint32_t nr; /**< Placement in input file */
     int location{-1};
     bool is_in_prechart{false};
+    explicit LSC_element_t(uint32_t nr): nr{nr} {}
     int get_nr() const { return nr; }
-    bool empty() const { return nr == -1; }
 };
 
 /** Information about a message. Messages have a source (src) and a
@@ -218,6 +218,7 @@ struct message_t : LSC_element_t
     instance_line_t* src{nullptr}; /**< Pointer to source instance line */
     instance_line_t* dst{nullptr}; /**< Pointer to destination instance line */
     expression_t label;            /**< The label */
+    explicit message_t(uint32_t nr): LSC_element_t{nr} {}
 };
 /** Information about a condition. Conditions have an anchor instance lines.
  * The label is stored as an expression.
@@ -227,6 +228,7 @@ struct condition_t : LSC_element_t
     std::vector<instance_line_t*> anchors{}; /**< Pointer to anchor instance lines */
     expression_t label;                      /**< The label */
     bool isHot{false};
+    explicit condition_t(uint32_t nr): LSC_element_t{nr} {}
 };
 
 /** Information about an update. Update have an anchor instance line.
@@ -236,11 +238,12 @@ struct update_t : LSC_element_t
 {
     instance_line_t* anchor{nullptr}; /**< Pointer to anchor instance line */
     expression_t label;               /**< The label */
+    explicit update_t(uint32_t nr): LSC_element_t{nr} {}
 };
 
 struct simregion_t : stringify_t<simregion_t>
 {
-    int nr{};
+    uint32_t nr{};
     message_t* message{nullptr};     /** May be empty */
     condition_t* condition{nullptr}; /** May be empty */
     update_t* update{nullptr};       /** May be empty */
@@ -252,9 +255,9 @@ struct simregion_t : stringify_t<simregion_t>
     bool has_message() const { return message != nullptr; }
     bool has_condition() const { return condition != nullptr; }
     bool has_update() const { return update != nullptr; }
-    void set_message(std::deque<message_t>& messages, int nr);
-    void set_condition(std::deque<condition_t>& conditions, int nr);
-    void set_update(std::deque<update_t>& updates, int nr);
+    void set_message(std::deque<message_t>& messages, uint32_t nr);
+    void set_condition(std::deque<condition_t>& conditions, uint32_t nr);
+    void set_update(std::deque<update_t>& updates, uint32_t nr);
 };
 
 struct compare_simregion
@@ -339,7 +342,7 @@ struct instance_t
  */
 struct instance_line_t : public instance_t
 {
-    int32_t instance_nr; /**< InstanceLine number in template */
+    uint32_t instance_nr; /**< InstanceLine number in template */
     std::vector<simregion_t> getSimregions(const std::vector<simregion_t>& simregions);
     void add_parameters(instance_t& inst, frame_t params, const std::vector<expression_t>& arguments);
 };

--- a/include/utap/document.h
+++ b/include/utap/document.h
@@ -248,20 +248,6 @@ struct simregion_t : stringify_t<simregion_t>
     int get_loc() const;
     bool is_in_prechart() const;
 
-    simregion_t()
-    {
-        message = new message_t();
-        condition = new condition_t();
-        update = new update_t();
-    }
-
-    ~simregion_t() noexcept
-    {
-        delete message;
-        delete condition;
-        delete update;
-    }
-
     std::ostream& print(std::ostream&) const;
     bool has_message() const { return message != nullptr && !message->empty(); }
     bool has_condition() const { return condition != nullptr && !condition->empty(); }

--- a/include/utap/document.h
+++ b/include/utap/document.h
@@ -241,17 +241,17 @@ struct update_t : LSC_element_t
 struct simregion_t : stringify_t<simregion_t>
 {
     int nr{};
-    message_t* message;     /** May be empty */
-    condition_t* condition; /** May be empty */
-    update_t* update;       /** May be empty */
+    message_t* message{nullptr};     /** May be empty */
+    condition_t* condition{nullptr}; /** May be empty */
+    update_t* update{nullptr};       /** May be empty */
 
     int get_loc() const;
     bool is_in_prechart() const;
 
     std::ostream& print(std::ostream&) const;
-    bool has_message() const { return message != nullptr && !message->empty(); }
-    bool has_condition() const { return condition != nullptr && !condition->empty(); }
-    bool has_update() const { return update != nullptr && !update->empty(); }
+    bool has_message() const { return message != nullptr; }
+    bool has_condition() const { return condition != nullptr; }
+    bool has_update() const { return update != nullptr; }
     void set_message(std::deque<message_t>& messages, int nr);
     void set_condition(std::deque<condition_t>& conditions, int nr);
     void set_update(std::deque<update_t>& updates, int nr);

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -621,6 +621,8 @@ bool simregion_t::is_in_prechart() const
 
 void simregion_t::set_message(std::deque<message_t>& messages, int nr)
 {
+    assert(nr != -1);
+
     for (auto& message : messages) {
         if (message.nr == nr) {
             this->message = &message;
@@ -631,6 +633,8 @@ void simregion_t::set_message(std::deque<message_t>& messages, int nr)
 
 void simregion_t::set_condition(std::deque<condition_t>& conditions, int nr)
 {
+    assert(nr != -1);
+
     for (auto& condition : conditions) {
         if (condition.nr == nr) {
             this->condition = &condition;
@@ -641,6 +645,8 @@ void simregion_t::set_condition(std::deque<condition_t>& conditions, int nr)
 
 void simregion_t::set_update(std::deque<update_t>& updates, int nr)
 {
+    assert(nr != -1);
+
     for (auto& update : updates) {
         if (update.nr == nr) {
             this->update = &update;

--- a/test/models/lsc_example.xml
+++ b/test/models/lsc_example.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE nta PUBLIC '-//Uppaal Team//DTD Flat System 1.1//EN' 'http://www.it.uu.se/research/group/darts/uppaal/flat-1_2.dtd'>
+<nta>
+	<declaration>// Place global declarations here.
+chan m1, m3, m4, m2;
+clock x;</declaration>
+	<template>
+		<name x="5" y="5">A</name>
+		<declaration>// Place local declarations here.
+</declaration>
+		<location id="id0" x="16" y="-40">
+		</location>
+		<init ref="id0"/>
+		<transition>
+			<source ref="id0"/>
+			<target ref="id0"/>
+			<label kind="synchronisation" x="0" y="32">m2?</label>
+			<nail x="56" y="32"/>
+			<nail x="-24" y="32"/>
+		</transition>
+		<transition>
+			<source ref="id0"/>
+			<target ref="id0"/>
+			<label kind="synchronisation" x="0" y="-136">m4?</label>
+			<nail x="-24" y="-112"/>
+			<nail x="56" y="-112"/>
+		</transition>
+	</template>
+	<template>
+		<name>B</name>
+		<location id="id1" x="0" y="96">
+			<name x="-8" y="128">loc2</name>
+			<label kind="invariant" x="-10" y="111">x&lt;=5</label>
+		</location>
+		<location id="id2" x="0" y="-48">
+			<name x="-16" y="-96">loc1</name>
+			<label kind="invariant" x="-16" y="-80">x&lt;=5</label>
+		</location>
+		<init ref="id2"/>
+		<transition>
+			<source ref="id1"/>
+			<target ref="id2"/>
+			<label kind="synchronisation" x="32" y="0">m2!</label>
+			<nail x="24" y="24"/>
+		</transition>
+		<transition>
+			<source ref="id2"/>
+			<target ref="id1"/>
+			<label kind="guard" x="-64" y="0">x&gt;=3</label>
+			<label kind="synchronisation" x="-64" y="15">m1!</label>
+			<nail x="-24" y="24"/>
+		</transition>
+	</template>
+	<template>
+		<name>C</name>
+		<location id="id3" x="96" y="96">
+			<name x="80" y="112">loc5</name>
+			<committed/>
+		</location>
+		<location id="id4" x="0" y="96">
+			<name x="-16" y="112">loc4</name>
+		</location>
+		<location id="id5" x="0" y="0">
+			<name x="-10" y="-30">loc3</name>
+		</location>
+		<init ref="id5"/>
+		<transition>
+			<source ref="id3"/>
+			<target ref="id5"/>
+			<label kind="synchronisation" x="96" y="24">m4!</label>
+			<nail x="96" y="0"/>
+		</transition>
+		<transition>
+			<source ref="id5"/>
+			<target ref="id4"/>
+			<label kind="synchronisation" x="-32" y="40">m1?</label>
+		</transition>
+		<transition>
+			<source ref="id4"/>
+			<target ref="id3"/>
+			<label kind="synchronisation" x="32" y="96">m3!</label>
+		</transition>
+	</template>
+	<template>
+		<name>D</name>
+		<location id="id6" x="0" y="104">
+		</location>
+		<location id="id7" x="0" y="0">
+		</location>
+		<init ref="id7"/>
+		<transition>
+			<source ref="id6"/>
+			<target ref="id7"/>
+			<nail x="-32" y="104"/>
+			<nail x="-32" y="0"/>
+		</transition>
+		<transition>
+			<source ref="id6"/>
+			<target ref="id6"/>
+			<label kind="synchronisation" x="-8" y="152">m4?</label>
+			<nail x="-16" y="152"/>
+			<nail x="24" y="152"/>
+		</transition>
+		<transition>
+			<source ref="id7"/>
+			<target ref="id6"/>
+			<label kind="synchronisation" x="8" y="32">m3?</label>
+		</transition>
+	</template>
+	<lsc>
+		<name>LscTemplate</name>
+		<parameter>int a, int b</parameter>
+		<type>Universal</type>
+		<mode>Invariant</mode>
+		<declaration>// Place local declarations here.
+</declaration>
+		<yloccoord number="0" y="0"/>
+		<yloccoord number="1" y="56"/>
+		<yloccoord number="2" y="104"/>
+		<yloccoord number="3" y="144"/>
+		<yloccoord number="4" y="168"/>
+		<yloccoord number="5" y="220"/>
+		<instance id="id8" x="432" y="0">
+			<name x="0" y="0">D</name>
+		</instance>
+		<instance id="id9" x="288" y="0">
+			<name x="0" y="0">C</name>
+		</instance>
+		<instance id="id10" x="144" y="0">
+			<name x="0" y="0">B</name>
+		</instance>
+		<instance id="id11" x="0" y="0">
+			<name x="0" y="0">A</name>
+		</instance>
+		<prechart x="0" y="104">
+			<lsclocation>2</lsclocation>
+		</prechart>
+		<message x="0" y="144">
+			<source ref="id10"/>
+			<target ref="id11"/>
+			<lsclocation>3</lsclocation>
+			<label kind="message" x="61" y="-18">m2</label>
+		</message>
+		<message x="0" y="168">
+			<source ref="id9"/>
+			<target ref="id8"/>
+			<lsclocation>4</lsclocation>
+			<label kind="message" x="357" y="-18">m3</label>
+		</message>
+		<message x="0" y="56">
+			<source ref="id10"/>
+			<target ref="id9"/>
+			<lsclocation>1</lsclocation>
+			<label kind="message" x="205" y="-18">m1</label>
+		</message>
+		<condition x="0" y="56">
+			<anchor instanceid="id9"/>
+			<lsclocation>1</lsclocation>
+			<temperature>cold</temperature>
+			<label kind="condition">x &gt;=b</label>
+		</condition>
+		<condition x="0" y="144">
+			<anchor instanceid="id11"/>
+			<lsclocation>3</lsclocation>
+			<temperature>hot</temperature>
+			<label kind="condition">x &gt;= a</label>
+		</condition>
+	</lsc>
+	<system>// Place template instantiations here.
+Scenario = LscTemplate(2,3);
+
+// List one or more processes to be composed into a system.
+system A, B, C, D;
+</system>
+	<queries>
+		<query>
+			<formula>sat: Scenario
+			</formula>
+			<comment>
+			</comment>
+		</query>
+	</queries>
+</nta>

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -254,3 +254,15 @@ TEST_CASE("Test leads to token is parsed correctly")
     auto f = document_fixture{}.add_default_process().build_query_fixture();
     CHECK_NOTHROW(f.parse_query("true --> true"));
 }
+
+TEST_CASE("Sim region cleanup causes memory errors (run with ASAN)")
+{
+    auto doc = read_document("lsc_example.xml");
+    REQUIRE(doc);
+    auto& errors = doc->get_errors();
+    CHECK(errors.size() == 0);
+
+    auto& templ = doc->get_templates().back();
+    auto sims = templ.get_simregions();
+    CHECK(sims.size() == 3);
+}


### PR DESCRIPTION
This issue happens when you parse a LSC model and then call `get_simregions()` on one of the LSC templates. This will construct `simregion_t` objects which has a faulty cleanup strategy.

See new test in `test_parser.cpp` for example