### PR TITLE
Fixed precedence issues with pre-increment and subscript

### DIFF
--- a/include/utap/expression.h
+++ b/include/utap/expression.h
@@ -214,6 +214,9 @@ public:
 
     expression_t subst(symbol_t, expression_t) const;
 
+    /**
+     * Precedence of expression type, higher precedence goes before low precedence
+     */
     static int get_precedence(Constants::kind_t);
 
     /** Create a CONSTANT expression. */

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -815,7 +815,7 @@ int expression_t::get_precedence(kind_t kind)
     case PRE_INCREMENT:
     case PRE_DECREMENT:
     case UNARY_MINUS:
-    case NOT: return 90;
+    case NOT: return 107;
 
     case FRACTION: return 14;
     case INLINE_IF: return 15;

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -815,7 +815,7 @@ int expression_t::get_precedence(kind_t kind)
     case PRE_INCREMENT:
     case PRE_DECREMENT:
     case UNARY_MINUS:
-    case NOT: return 107;
+    case NOT: return 90;
 
     case FRACTION: return 14;
     case INLINE_IF: return 15;

--- a/src/parser.y
+++ b/src/parser.y
@@ -316,8 +316,8 @@ const char* utap_msg(const char *msg)
 %left T_MULT T_DIV T_MOD
 %left T_POWOP
 %right T_EXCLAM T_KW_NOT UOPERATOR
-%left '(' ')' '[' ']' '.' '\''
 %right T_INCREMENT T_DECREMENT
+%left '(' ')' '[' ']' '.' '\''
 
 
 %union {

--- a/src/parser.y
+++ b/src/parser.y
@@ -1207,7 +1207,7 @@ Expression:
         | '(' error ')' {
           CALL(@1, @3, expr_false());
         }
-        | Expression T_INCREMENT {
+        | Expression T_INCREMENT %prec '[' {
           CALL(@1, @2, expr_post_increment());
         }
         | T_INCREMENT Expression {

--- a/test/test_expression.cpp
+++ b/test/test_expression.cpp
@@ -75,9 +75,9 @@ TEST_CASE("Expression")
         REQUIRE(exp_t::get_precedence(FUN_CALL) == exp_t::get_precedence(FUN_CALL_EXT));
         REQUIRE(exp_t::get_precedence(FUN_CALL) >= exp_t::get_precedence(ARRAY));
         REQUIRE(exp_t::get_precedence(ARRAY) >= exp_t::get_precedence(DOT));
+        REQUIRE(exp_t::get_precedence(ARRAY) > exp_t::get_precedence(NOT));
         REQUIRE(exp_t::get_precedence(DOT) >= exp_t::get_precedence(RATE));
         REQUIRE(exp_t::get_precedence(PRE_INCREMENT) == exp_t::get_precedence(NOT));
-        REQUIRE(exp_t::get_precedence(NOT) < exp_t::get_precedence(ARRAY));
         REQUIRE(exp_t::get_precedence(PRE_INCREMENT) == exp_t::get_precedence(PRE_DECREMENT));
         REQUIRE(exp_t::get_precedence(PRE_INCREMENT) >= exp_t::get_precedence(UNARY_MINUS));
         REQUIRE(exp_t::get_precedence(UNARY_MINUS) >= exp_t::get_precedence(NOT));

--- a/test/test_expression.cpp
+++ b/test/test_expression.cpp
@@ -76,7 +76,8 @@ TEST_CASE("Expression")
         REQUIRE(exp_t::get_precedence(FUN_CALL) >= exp_t::get_precedence(ARRAY));
         REQUIRE(exp_t::get_precedence(ARRAY) >= exp_t::get_precedence(DOT));
         REQUIRE(exp_t::get_precedence(DOT) >= exp_t::get_precedence(RATE));
-        REQUIRE(exp_t::get_precedence(PRE_INCREMENT) > exp_t::get_precedence(ARRAY));
+        REQUIRE(exp_t::get_precedence(PRE_INCREMENT) == exp_t::get_precedence(NOT));
+        REQUIRE(exp_t::get_precedence(NOT) < exp_t::get_precedence(ARRAY));
         REQUIRE(exp_t::get_precedence(PRE_INCREMENT) == exp_t::get_precedence(PRE_DECREMENT));
         REQUIRE(exp_t::get_precedence(PRE_INCREMENT) >= exp_t::get_precedence(UNARY_MINUS));
         REQUIRE(exp_t::get_precedence(UNARY_MINUS) >= exp_t::get_precedence(NOT));

--- a/test/test_expression.cpp
+++ b/test/test_expression.cpp
@@ -76,7 +76,7 @@ TEST_CASE("Expression")
         REQUIRE(exp_t::get_precedence(FUN_CALL) >= exp_t::get_precedence(ARRAY));
         REQUIRE(exp_t::get_precedence(ARRAY) >= exp_t::get_precedence(DOT));
         REQUIRE(exp_t::get_precedence(DOT) >= exp_t::get_precedence(RATE));
-        REQUIRE(exp_t::get_precedence(RATE) > exp_t::get_precedence(PRE_INCREMENT));
+        REQUIRE(exp_t::get_precedence(PRE_INCREMENT) > exp_t::get_precedence(ARRAY));
         REQUIRE(exp_t::get_precedence(PRE_INCREMENT) == exp_t::get_precedence(PRE_DECREMENT));
         REQUIRE(exp_t::get_precedence(PRE_INCREMENT) >= exp_t::get_precedence(UNARY_MINUS));
         REQUIRE(exp_t::get_precedence(UNARY_MINUS) >= exp_t::get_precedence(NOT));

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -300,6 +300,17 @@ TEST_CASE("pre post increment precedence")
     CHECK(doc->get_errors().size() == 1);
 }
 
+TEST_CASE("Double pre increment with forced precedence")
+{
+    auto doc = document_fixture{}
+                   .add_global_decl("int i = 0;")
+                   .add_global_decl("void f(){ (++i)++; }")
+                   .add_default_process()
+                   .parse();
+
+    CHECK_MESSAGE(doc->get_errors().size() == 0, doc->get_errors().at(0).msg);
+}
+
 TEST_CASE("Double pre increment precedence")
 {
     auto doc = document_fixture{}

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -275,5 +275,38 @@ TEST_CASE("Pre increment precedence bug")
                    .add_default_process()
                    .parse();
 
-    CHECK(doc->get_errors().size() == 0);
+    CHECK_MESSAGE(doc->get_errors().size() == 0, doc->get_errors().at(0).msg);
+}
+
+TEST_CASE("Double post increment precedence")
+{
+    auto doc = document_fixture{}
+                   .add_global_decl("int i = 0;")
+                   .add_global_decl("void f(){ i++++; }")
+                   .add_default_process()
+                   .parse();
+
+    CHECK(doc->get_errors().size() == 1);
+}
+
+TEST_CASE("pre post increment precedence")
+{
+    auto doc = document_fixture{}
+                   .add_global_decl("int i = 0;")
+                   .add_global_decl("void f(){ ++i++; }")
+                   .add_default_process()
+                   .parse();
+
+    CHECK(doc->get_errors().size() == 1);
+}
+
+TEST_CASE("Double pre increment precedence")
+{
+    auto doc = document_fixture{}
+                   .add_global_decl("int i = 0;")
+                   .add_global_decl("void f(){ ++++i; }")
+                   .add_default_process()
+                   .parse();
+
+    CHECK_MESSAGE(doc->get_errors().size() == 0, doc->get_errors().at(0).msg);
 }

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -266,3 +266,14 @@ TEST_CASE("Sim region cleanup causes memory errors (run with ASAN)")
     auto sims = templ.get_simregions();
     CHECK(sims.size() == 3);
 }
+
+TEST_CASE("Pre increment precedence bug")
+{
+    auto doc = document_fixture{}
+                   .add_global_decl("int i[2];")
+                   .add_global_decl("void f(){ ++i[0]; }")
+                   .add_default_process()
+                   .parse();
+
+    CHECK(doc->get_errors().size() == 0);
+}

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -278,6 +278,17 @@ TEST_CASE("Pre increment precedence bug")
     CHECK_MESSAGE(doc->get_errors().size() == 0, doc->get_errors().at(0).msg);
 }
 
+TEST_CASE("Post increment precedence bug")
+{
+    auto doc = document_fixture{}
+                   .add_global_decl("int i[2];")
+                   .add_global_decl("void f(){ i[0]++; }")
+                   .add_default_process()
+                   .parse();
+
+    CHECK_MESSAGE(doc->get_errors().size() == 0, doc->get_errors().at(0).msg);
+}
+
 TEST_CASE("Double post increment precedence")
 {
     auto doc = document_fixture{}
@@ -316,6 +327,28 @@ TEST_CASE("Double pre increment precedence")
     auto doc = document_fixture{}
                    .add_global_decl("int i = 0;")
                    .add_global_decl("void f(){ ++++i; }")
+                   .add_default_process()
+                   .parse();
+
+    CHECK_MESSAGE(doc->get_errors().size() == 0, doc->get_errors().at(0).msg);
+}
+
+TEST_CASE("Increment with array subscripting and dot accessing")
+{
+    auto doc = document_fixture{}
+                   .add_global_decl("struct { int x, y; } axy[2];")
+                   .add_global_decl("void f(){ ++axy[0].x; axy[0].x++; }")
+                   .add_default_process()
+                   .parse();
+
+    CHECK_MESSAGE(doc->get_errors().size() == 0, doc->get_errors().at(0).msg);
+}
+
+TEST_CASE("Increment with multiple array subscripting and dot accessing")
+{
+    auto doc = document_fixture{}
+                   .add_global_decl("struct { int ai[2]; } aai[2];")
+                   .add_global_decl("void f(){ ++aai[0].ai[0]; aai[0].ai[0]++; }")
                    .add_default_process()
                    .parse();
 


### PR DESCRIPTION
Do note this changes also changes post increment precedence but tests and regressions didn't fail and I can't find a counter example.