### PR TITLE
Updated libxml2 to 2.11.5 and changed source to mirrors

### DIFF
--- a/cmake/libxml2.cmake
+++ b/cmake/libxml2.cmake
@@ -16,17 +16,20 @@ else(LibXml2_FOUND)
     seT(LIBXML2_WITH_THREADS OFF CACHE BOOL "LibXml2 multithread support")
     set(LIBXML2_WITH_TESTS OFF CACHE BOOL "LibXml2 Tests")
     FetchContent_Declare(LibXml2
-            GIT_REPOSITORY https://gitlab.gnome.org/GNOME/libxml2
-            GIT_TAG v2.11.4
-            GIT_SHALLOW ON
-            GIT_PROGRESS ON
-            UPDATE_DISCONNECTED ON
-            USES_TERMINAL_DOWNLOAD ON
-            USES_TERMINAL_CONFIGURE ON
-            USES_TERMINAL_BUILD ON
-            USES_TERMINAL_INSTALL ON
-            FIND_PACKAGE_ARGS NAMES LibXml2
-            )
+      URL https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.5.tar.xz
+      URL_HASH SHA256=3727b078c360ec69fa869de14bd6f75d7ee8d36987b071e6928d4720a28df3a6
+      #GIT_REPOSITORY https://gitlab.gnome.org/GNOME/libxml2 # often down
+      #GIT_REPOSITORY https://github.com/GNOME/libxml2.git # mirror
+      #GIT_TAG v2.11.5
+      GIT_SHALLOW ON
+      GIT_PROGRESS ON
+      UPDATE_DISCONNECTED ON
+      USES_TERMINAL_DOWNLOAD ON
+      USES_TERMINAL_CONFIGURE ON
+      USES_TERMINAL_BUILD ON
+      USES_TERMINAL_INSTALL ON
+      FIND_PACKAGE_ARGS NAMES LibXml2
+    )
     FetchContent_MakeAvailable(LibXml2)
     message(STATUS "Got LibXml2.")
 endif(LibXml2_FOUND)

--- a/cmake/libxml2.cmake
+++ b/cmake/libxml2.cmake
@@ -16,11 +16,11 @@ else(LibXml2_FOUND)
     seT(LIBXML2_WITH_THREADS OFF CACHE BOOL "LibXml2 multithread support")
     set(LIBXML2_WITH_TESTS OFF CACHE BOOL "LibXml2 Tests")
     FetchContent_Declare(LibXml2
-      URL https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.5.tar.xz
-      URL_HASH SHA256=3727b078c360ec69fa869de14bd6f75d7ee8d36987b071e6928d4720a28df3a6
+      GIT_REPOSITORY https://github.com/GNOME/libxml2.git # mirror
       #GIT_REPOSITORY https://gitlab.gnome.org/GNOME/libxml2 # often down
-      #GIT_REPOSITORY https://github.com/GNOME/libxml2.git # mirror
-      #GIT_TAG v2.11.5
+      GIT_TAG v2.11.5
+      #URL https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.5.tar.xz
+      #URL_HASH SHA256=3727b078c360ec69fa869de14bd6f75d7ee8d36987b071e6928d4720a28df3a6
       GIT_SHALLOW ON
       GIT_PROGRESS ON
       UPDATE_DISCONNECTED ON

--- a/getlibs/sources.sh
+++ b/getlibs/sources.sh
@@ -8,10 +8,10 @@ SOURCE="$LOCAL/source"
 BW="\e[1;97m" # bold white
 NC="\e[0m"    # no color
 
-LIBXML2=libxml2-2.11.4
+LIBXML2=libxml2-2.11.5
 LIBXML2_Z="${LIBXML2}.tar.xz"
 LIBXML2_URL="https://people.cs.aau.dk/~marius/mirrors/libxml2/${LIBXML2_Z}"
-LIBXML2_SHA256=737e1d7f8ab3f139729ca13a2494fd17bf30ddb4b7a427cf336252cab57f57f7
+LIBXML2_SHA256=3727b078c360ec69fa869de14bd6f75d7ee8d36987b071e6928d4720a28df3a6
 
 DOCTEST=doctest-2.4.11
 DOCTEST_Z="${DOCTEST}.tar.gz"


### PR DESCRIPTION
The official gitlab is (temporarily) down (gives HTTP Error 503), so changed to next mirror.