### PR TITLE
Coshy

### DIFF
--- a/include/utap/AbstractBuilder.hpp
+++ b/include/utap/AbstractBuilder.hpp
@@ -180,6 +180,7 @@ public:
     void expr_false() override;
     void expr_double(double) override;
     void expr_string(const char*) override;
+    void expr_location(const char* name) override;
     void expr_location() override;
     void expr_identifier(const char* varName) override;
     void expr_nat(int32_t) override;  // natural number

--- a/include/utap/AbstractBuilder.hpp
+++ b/include/utap/AbstractBuilder.hpp
@@ -284,6 +284,10 @@ public:
     void expr_MITL_exists_dynamic_begin(const char*, const char*) override;
     void expr_MITL_exists_dynamic_end(const char* name) override;
 
+    void expr_enforce() override;
+    void expr_discrete_interval() override;
+    void expr_interval(int32_t divisions) override;
+
     /** Verification queries */
     void model_option(const char* key, const char* value) override;
     void query_begin() override;

--- a/include/utap/AbstractBuilder.hpp
+++ b/include/utap/AbstractBuilder.hpp
@@ -285,7 +285,7 @@ public:
     void expr_MITL_exists_dynamic_begin(const char*, const char*) override;
     void expr_MITL_exists_dynamic_end(const char* name) override;
 
-    void expr_enforce() override;
+    void expr_acontrol() override;
     void expr_discrete_interval() override;
     void expr_interval(int32_t divisions) override;
 

--- a/include/utap/ExpressionBuilder.hpp
+++ b/include/utap/ExpressionBuilder.hpp
@@ -206,6 +206,10 @@ public:
     void expr_MITL_diamond(int, int) override;
     void expr_MITL_box(int, int) override;
 
+    void expr_enforce() override;
+    void expr_discrete_interval() override;
+    void expr_interval(int32_t divisions) override;
+
     /* Dynamic process creation */
     void expr_spawn(int params) override;
     void expr_exit() override;

--- a/include/utap/ExpressionBuilder.hpp
+++ b/include/utap/ExpressionBuilder.hpp
@@ -175,6 +175,7 @@ public:
     void expr_ternary(Constants::kind_t ternaryop, bool firstMissing) override;
     void expr_inline_if() override;
     void expr_comma() override;
+    void expr_location(const char* name);
     void expr_dot(const char*) override;
     void expr_deadlock() override;
     void expr_forall_begin(const char* name) override;

--- a/include/utap/ExpressionBuilder.hpp
+++ b/include/utap/ExpressionBuilder.hpp
@@ -207,7 +207,7 @@ public:
     void expr_MITL_diamond(int, int) override;
     void expr_MITL_box(int, int) override;
 
-    void expr_enforce() override;
+    void expr_acontrol() override;
     void expr_discrete_interval() override;
     void expr_interval(int32_t divisions) override;
 

--- a/include/utap/builder.h
+++ b/include/utap/builder.h
@@ -430,6 +430,10 @@ public:
     virtual void expr_MITL_exists_dynamic_end(const char* name) = 0;
     virtual void expr_dynamic_process_expr(const char*) = 0;
 
+    virtual void expr_enforce() = 0;
+    virtual void expr_discrete_interval() = 0;
+    virtual void expr_interval(int32_t divisions) = 0;
+
     /** Verification queries */
     virtual void model_option(const char* key, const char* value) = 0;
     virtual void query_begin() = 0;

--- a/include/utap/builder.h
+++ b/include/utap/builder.h
@@ -319,6 +319,7 @@ public:
     virtual void expr_double(double) = 0;
     virtual void expr_string(const char* name) = 0;
     virtual void expr_identifier(const char* varName) = 0;
+    virtual void expr_location(const char* name) = 0;
     virtual void expr_location() = 0;
     virtual void expr_nat(int32_t) = 0;  // natural number
     virtual void expr_call_begin() = 0;

--- a/include/utap/builder.h
+++ b/include/utap/builder.h
@@ -431,7 +431,7 @@ public:
     virtual void expr_MITL_exists_dynamic_end(const char* name) = 0;
     virtual void expr_dynamic_process_expr(const char*) = 0;
 
-    virtual void expr_enforce() = 0;
+    virtual void expr_acontrol() = 0;
     virtual void expr_discrete_interval() = 0;
     virtual void expr_interval(int32_t divisions) = 0;
 

--- a/include/utap/common.h
+++ b/include/utap/common.h
@@ -278,6 +278,15 @@ enum kind_t {
     MITL_ATOM,
     MITL_EXISTS,
     MITL_FORALL,
+
+    /******************************************************
+     * HYPA
+     */
+    ENFORCE,
+    DISCRETE_INTERVAL,
+    INTERVAL,
+    INTERVAL_LIST,
+
     /*Dynamic */
     SPAWN,
     EXIT,

--- a/include/utap/common.h
+++ b/include/utap/common.h
@@ -282,7 +282,7 @@ enum kind_t {
     /******************************************************
      * HYPA
      */
-    ENFORCE,
+    ACONTROL,
     DISCRETE_INTERVAL,
     INTERVAL,
     INTERVAL_LIST,

--- a/include/utap/property.h
+++ b/include/utap/property.h
@@ -108,7 +108,10 @@ enum class quant_t {
     PMax,
 
     /* LSC scenario property */
-    scenario
+    scenario,
+
+    /* HYPA: enforce : ... {} -> {} */
+    enforce,
 };
 
 /** property status */

--- a/include/utap/property.h
+++ b/include/utap/property.h
@@ -110,8 +110,8 @@ enum class quant_t {
     /* LSC scenario property */
     scenario,
 
-    /* HYPA: enforce : ... {} -> {} */
-    enforce,
+    /* HYPA: acontrol: A[] ... {} -> {} */
+    acontrol,
 };
 
 /** property status */

--- a/src/ExpressionBuilder.cpp
+++ b/src/ExpressionBuilder.cpp
@@ -931,13 +931,13 @@ void ExpressionBuilder::expr_MITL_box(int low, int high)
     fragments.push(form);
 }
 
-void ExpressionBuilder::expr_enforce()
+void ExpressionBuilder::expr_acontrol()
 {
     const auto partition = fragments[0];
     assert(partition.get_kind() == INTERVAL_LIST);
     const auto to_enforce = fragments[1];
     fragments.pop(2);
-    fragments.push(expression_t::create_binary(ENFORCE, to_enforce, partition, position));
+    fragments.push(expression_t::create_binary(ACONTROL, to_enforce, partition, position));
 }
 
 void ExpressionBuilder::expr_discrete_interval()

--- a/src/ExpressionBuilder.cpp
+++ b/src/ExpressionBuilder.cpp
@@ -750,7 +750,7 @@ void ExpressionBuilder::expr_load_strategy()
 
 void ExpressionBuilder::expr_save_strategy(const char* strategy_name)
 {
-    assert(fragments.size() == 1);
+    //assert(fragments.size() == 1);
     fragments[0] = expression_t::create_binary(SAVE_STRAT, fragments[0], make_constant(strategy_name), position);
 }
 

--- a/src/ExpressionBuilder.cpp
+++ b/src/ExpressionBuilder.cpp
@@ -557,6 +557,20 @@ void ExpressionBuilder::expr_comma()
     fragments.push(expression_t::create_binary(COMMA, e1, e2, position, e2.get_type()));
 }
 
+void ExpressionBuilder::expr_location(const char* name)
+{
+
+    symbol_t uid;
+
+    if (!resolve(name, uid)) {
+        expr_false();
+        throw UnknownIdentifierError(name);
+    }
+
+    fragments.push(expression_t::create_identifier(uid, position));
+    expr_location();
+}
+
 void ExpressionBuilder::expr_location()
 {
     expression_t expr = fragments[0];

--- a/src/ExpressionBuilder.cpp
+++ b/src/ExpressionBuilder.cpp
@@ -917,6 +917,38 @@ void ExpressionBuilder::expr_MITL_box(int low, int high)
     fragments.push(form);
 }
 
+void ExpressionBuilder::expr_enforce()
+{
+    const auto partition = fragments[0];
+    assert(partition.get_kind() == INTERVAL_LIST);
+    const auto to_enforce = fragments[1];
+    fragments.pop(2);
+    fragments.push(expression_t::create_binary(ENFORCE, to_enforce, partition, position));
+}
+
+void ExpressionBuilder::expr_discrete_interval()
+{
+    const auto identifier = fragments[0];
+    const auto upper = fragments[1];
+    const auto lower = fragments[2];
+    fragments.pop(3);
+    auto args = std::vector{identifier, lower, upper};
+    const auto discrete_interval = expression_t::create_nary(DISCRETE_INTERVAL, std::move(args), position);
+    fragments.push(discrete_interval);
+}
+
+void ExpressionBuilder::expr_interval(int32_t divisions)
+{
+    const auto identifier = fragments[0];
+    const auto upper = fragments[1];
+    const auto lower = fragments[2];
+    fragments.pop(3);
+    const auto divisions2 = expression_t::create_constant(divisions, position);
+    auto args = std::vector{identifier, lower, upper, divisions2};
+    const auto interval = expression_t::create_nary(INTERVAL, std::move(args), position);
+    fragments.push(interval);
+}
+
 void ExpressionBuilder::expr_MITL_disj()
 {
     auto& left = fragments[1];

--- a/src/abstractbuilder.cpp
+++ b/src/abstractbuilder.cpp
@@ -199,6 +199,7 @@ void AbstractBuilder::expr_ternary(Constants::kind_t ternaryop, bool firstMissin
 void AbstractBuilder::expr_inline_if() { UNSUPPORTED; }
 void AbstractBuilder::expr_comma() { UNSUPPORTED; }
 void AbstractBuilder::expr_location() { UNSUPPORTED; }
+void AbstractBuilder::expr_location(const char* name) { UNSUPPORTED; }
 void AbstractBuilder::expr_dot(const char*) { UNSUPPORTED; }
 void AbstractBuilder::expr_deadlock() { UNSUPPORTED; }
 void AbstractBuilder::expr_forall_begin(const char* name) { UNSUPPORTED; }

--- a/src/abstractbuilder.cpp
+++ b/src/abstractbuilder.cpp
@@ -276,6 +276,10 @@ void AbstractBuilder::expr_MITL_forall_dynamic_end(const char* name) { UNSUPPORT
 void AbstractBuilder::expr_MITL_exists_dynamic_begin(const char*, const char*) { UNSUPPORTED; }
 void AbstractBuilder::expr_MITL_exists_dynamic_end(const char* name) { UNSUPPORTED; }
 
+void AbstractBuilder::expr_enforce() { UNSUPPORTED; }
+void AbstractBuilder::expr_discrete_interval() { UNSUPPORTED; }
+void AbstractBuilder::expr_interval(int32_t divisions) { UNSUPPORTED; }
+
 void AbstractBuilder::query_begin() { UNSUPPORTED; }
 void AbstractBuilder::query_end() { UNSUPPORTED; }
 void AbstractBuilder::query_formula(const char*, const char*) { UNSUPPORTED; }

--- a/src/abstractbuilder.cpp
+++ b/src/abstractbuilder.cpp
@@ -277,7 +277,7 @@ void AbstractBuilder::expr_MITL_forall_dynamic_end(const char* name) { UNSUPPORT
 void AbstractBuilder::expr_MITL_exists_dynamic_begin(const char*, const char*) { UNSUPPORTED; }
 void AbstractBuilder::expr_MITL_exists_dynamic_end(const char* name) { UNSUPPORTED; }
 
-void AbstractBuilder::expr_enforce() { UNSUPPORTED; }
+void AbstractBuilder::expr_acontrol() { UNSUPPORTED; }
 void AbstractBuilder::expr_discrete_interval() { UNSUPPORTED; }
 void AbstractBuilder::expr_interval(int32_t divisions) { UNSUPPORTED; }
 

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -440,6 +440,7 @@ size_t expression_t::get_size() const
     case FUN_CALL:
     case FUN_CALL_EXT:
     case LIST:
+    case INTERVAL_LIST:
     case SIMULATE:
     case SIMULATEREACH:
     case SPAWN: return std::get<int32_t>(data->value);
@@ -492,6 +493,9 @@ size_t expression_t::get_size() const
     case MITL_FORALL:
     case FOREACH_DYNAMIC: assert(data->sub.size() == 3); return 3;
     case DYNAMIC_EVAL: assert(data->sub.size() == 2); return 2;
+    case ENFORCE: assert(data->sub.size() == 2); return 2;
+    case DISCRETE_INTERVAL: assert(data->sub.size() == 3); return 3;
+    case INTERVAL: assert(data->sub.size() == 4); return 4;
     default: assert(0); return 0;
     }
 }
@@ -1661,6 +1665,42 @@ std::ostream& expression_t::print(std::ostream& os, bool old) const
         get(2).print(os, old) << ")";
         break;
     case TYPEDEF: os << "typedef"; break;
+
+    case ENFORCE:
+        os << "enforce: ";
+        get(0).print(os, old);
+        get(1).print(os, old);
+        break;
+
+    case INTERVAL_LIST:
+        os << " { ";
+        for (size_t i = 0; i < get_size(); ++i) {
+            get(i).print(os, old);
+            if (i + 1 < get_size()) {
+                os << ", ";
+            }
+        }
+        os << " }";
+        break;
+
+    case INTERVAL:
+        get(0).print(os, old);
+        os << "[";
+        get(1).print(os, old);
+        os << ", ";
+        get(2).print(os, old);
+        os << "]:";
+        get(3).print(os, old);
+        break;
+
+    case DISCRETE_INTERVAL:
+        get(0).print(os, old);
+        os << "[";
+        get(1).print(os, old);
+        os << ", ";
+        get(2).print(os, old);
+        os << "]";
+        break;
 
     // Types - Not applicable in expression printing
     case RANGE:

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -493,7 +493,7 @@ size_t expression_t::get_size() const
     case MITL_FORALL:
     case FOREACH_DYNAMIC: assert(data->sub.size() == 3); return 3;
     case DYNAMIC_EVAL: assert(data->sub.size() == 2); return 2;
-    case ENFORCE: assert(data->sub.size() == 2); return 2;
+    case ACONTROL: assert(data->sub.size() == 2); return 2;
     case DISCRETE_INTERVAL: assert(data->sub.size() == 3); return 3;
     case INTERVAL: assert(data->sub.size() == 4); return 4;
     default: assert(0); return 0;
@@ -1666,8 +1666,8 @@ std::ostream& expression_t::print(std::ostream& os, bool old) const
         break;
     case TYPEDEF: os << "typedef"; break;
 
-    case ENFORCE:
-        os << "enforce: ";
+    case ACONTROL:
+        os << "acontrol: A[] ";
         get(0).print(os, old);
         get(1).print(os, old);
         break;

--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -149,7 +149,7 @@ namespace UTAP {
             {"foreach",       Keyword{T_FOREACH, syntax_t::PROPERTY}},
             {"query",         Keyword{T_QUERY, syntax_t::NEW}},
             {"location",      Keyword{T_LOCATION, syntax_t::NEW}},
-            {"enforce",       Keyword{T_ENFORCE, syntax_t::NEW_PROPERTY}},
+            {"acontrol",       Keyword{T_ACRONTROL, syntax_t::NEW_PROPERTY}},
     };
 // clang-format on
 

--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -149,6 +149,7 @@ namespace UTAP {
             {"foreach",       Keyword{T_FOREACH, syntax_t::PROPERTY}},
             {"query",         Keyword{T_QUERY, syntax_t::NEW}},
             {"location",      Keyword{T_LOCATION, syntax_t::NEW}},
+            {"enforce",       Keyword{T_ENFORCE, syntax_t::NEW_PROPERTY}},
     };
 // clang-format on
 

--- a/src/parser.y
+++ b/src/parser.y
@@ -234,6 +234,9 @@ const char* utap_msg(const char *msg)
 /* Control Synthesis */
 %token T_CONTROL T_CONTROL_T T_SIMULATION
 
+/* HYPA */
+%token T_ACRONTROL
+
 /* Expectation optimization */
 %token T_MINEXP T_MAXEXP T_MINPR T_MAXPR T_STRATEGY T_LOAD_STRAT T_SAVE_STRAT
 
@@ -283,8 +286,6 @@ const char* utap_msg(const char *msg)
 %token T_DYNAMIC T_HYBRID
 %token T_SPAWN T_EXIT T_NUMOF
 
-/* HYPA */
-%token T_ENFORCE
 
 %type <kind> ExpQuantifier ExpPrQuantifier
 %type <kind> PathType
@@ -1830,8 +1831,8 @@ AssignablePropperty:
 	CALL(@1, @4, expr_unary(EF_CONTROL));
 	CALL(@1, @4, property());
     }
-    | T_ENFORCE ':' Expression Partition {
-    	CALL(@1, @4, expr_enforce());
+    | T_ACRONTROL ':' T_AG Expression Partition {
+    	CALL(@1, @4, expr_acontrol());
     	CALL(@1, @4, property());
     }
     | BracketExprList T_CONTROL ':' SubProperty Subjection {

--- a/src/parser.y
+++ b/src/parser.y
@@ -1800,6 +1800,9 @@ Interval:
 		CALL(@1, @1, expr_identifier($1));
 		CALL(@1, @8, expr_interval($8));
 	}
+	| T_ID '.' T_LOCATION {
+		CALL(@1, @3, expr_location($1));
+	}
 	;
 
 

--- a/src/property.cpp
+++ b/src/property.cpp
@@ -230,7 +230,7 @@ void PropertyBuilder::typeProperty(expression_t expr)  // NOLINT
         prob = true;
         break;
     case MITL_FORMULA: properties.back().type = quant_t::Mitl; break;
-    case ENFORCE: properties.back().type = quant_t::enforce; break;
+    case ACONTROL: properties.back().type = quant_t::acontrol; break;
     default: throw UTAP::TypeException("$Invalid_property_type"); prob = true;
     }
 

--- a/src/property.cpp
+++ b/src/property.cpp
@@ -230,6 +230,7 @@ void PropertyBuilder::typeProperty(expression_t expr)  // NOLINT
         prob = true;
         break;
     case MITL_FORMULA: properties.back().type = quant_t::Mitl; break;
+    case ENFORCE: properties.back().type = quant_t::enforce; break;
     default: throw UTAP::TypeException("$Invalid_property_type"); prob = true;
     }
 

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -134,6 +134,9 @@ bool type_t::is_prefix() const
     case Constants::TYPEDEF:
     case Constants::LABEL:
     case Constants::RATE:
+    case Constants::INTERVAL:
+    case Constants::DISCRETE_INTERVAL:
+    case Constants::INTERVAL_LIST:
     case Constants::INSTANCE_LINE:  // LSC
     case Constants::MESSAGE:        // LSC
     case Constants::CONDITION:      // LSC

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -2262,10 +2262,12 @@ bool TypeChecker::checkExpression(expression_t expr)
         break;
 
     case INTERVAL: {
-        const auto lower = expr[0].get_type();
-        const auto upper = expr[1].get_type();
-        const auto divisions = expr[2].get_type();
-        if ((lower.is_integer() || lower.is_double() || lower.is_clock()) &&
+        const auto ident = expr[0].get_type();
+        const auto lower = expr[1].get_type();
+        const auto upper = expr[2].get_type();
+        const auto divisions = expr[3].get_type();
+        if ((ident.is_integer() || ident.is_double() || ident.is_clock()) &&
+            (lower.is_integer() || lower.is_double() || lower.is_clock()) &&
             (upper.is_integer() || upper.is_double() || upper.is_clock()) && divisions.is_integer()) {
             type = type_t::create_primitive(INTERVAL);
         }

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -1013,7 +1013,7 @@ static bool isGameProperty(expression_t expr)
     case PO_CONTROL:
     case CONTROL_TOPT_DEF1:
     case CONTROL_TOPT_DEF2:
-    case ENFORCE: return true;
+    case ACONTROL: return true;
     default: return false;
     }
 }
@@ -2277,7 +2277,7 @@ bool TypeChecker::checkExpression(expression_t expr)
         }
         break;
 
-    case ENFORCE:
+    case ACONTROL:
         if (expr[0].get_type().is_integral() && is_interval_list(expr[1])) {
             type = type_t::create_primitive(FORMULA);
         }

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -185,7 +185,8 @@ static bool is_interval_list(expression_t expression)
 {
     const auto n_expressions = expression.get_size();
     for (size_t i = 0; i < n_expressions; ++i) {
-        if (!(expression[i].get_type().is(INTERVAL) || expression[i].get_type().is(DISCRETE_INTERVAL)))
+        auto e = expression[i];
+        if (!(e.get_type().is(INTERVAL) || e.get_type().is(DISCRETE_INTERVAL) || e.get_type().is(LOCATION_EXPR)))
             return false;
     }
 

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -2261,10 +2261,11 @@ bool TypeChecker::checkExpression(expression_t expr)
         break;
 
     case INTERVAL: {
-        const auto e0 = expr[0].get_type();
-        const auto e1 = expr[1].get_type();
-        const auto e2 = expr[2].get_type();
-        if ((e0.is_integer() || e0.is_double()) && (e1.is_integer() || e1.is_double())  && e2.is_integer()) {
+        const auto lower = expr[0].get_type();
+        const auto upper = expr[1].get_type();
+        const auto divisions = expr[2].get_type();
+        if ((lower.is_integer() || lower.is_double() || lower.is_clock()) &&
+            (upper.is_integer() || upper.is_double() || upper.is_clock()) && divisions.is_integer()) {
             type = type_t::create_primitive(INTERVAL);
         }
     } break;

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -2278,7 +2278,7 @@ bool TypeChecker::checkExpression(expression_t expr)
         break;
 
     case ACONTROL:
-        if (expr[0].get_type().is_integral() && is_interval_list(expr[1])) {
+        if (expr[0].get_type().is_guard() && is_interval_list(expr[1])) {
             type = type_t::create_primitive(FORMULA);
         }
         break;

--- a/test/test_prettyprint.cpp
+++ b/test/test_prettyprint.cpp
@@ -368,18 +368,12 @@ TEST_CASE("acontrol query")
 
     SUBCASE("Mixing some clocks in there")
     {
-        // Expressions involving clocks typecheck as invariants.
-        // Invariants aren't considered boolean expressions for some reason. I don't consider this my problem.
-        // The workaround is to add a floating-point number to the clock to appease the type checker.
-        const std::string query_string = "acontrol: A[] myClock + 0.0 < 10 && myClock + 0.0 > 0 { myClock[-1, 10]:100 }";
+        const std::string query_string = "acontrol: A[] myClock < 10 && myClock > 0 { myClock[-1, 10]:100 }";
 
         auto query1 = f.parse_query(query_string.data()).intermediate;
 
-        // And then I have to respect that the prettyprinter prints `0` instead of `0.0` for doubles.
-        // Also not my problem. And no, adding `0` in the query does not work.
-        const std::string expected_string = "acontrol: A[] myClock + 0 < 10 && myClock + 0 > 0 { myClock[-1, 10]:100 }";
         REQUIRE(query1.get_kind() == UTAP::Constants::ACONTROL);
-        CHECK(expected_string == query1.str());
+        CHECK(query_string == query1.str());
     }
 
     SUBCASE("Invalid condition to enforce")

--- a/test/test_prettyprint.cpp
+++ b/test/test_prettyprint.cpp
@@ -338,6 +338,18 @@ TEST_CASE("Enforce query")
     const auto foo = f.get_errors();
     REQUIRE(f.get_errors().empty());
 
+    SUBCASE("Support of locations")
+    {
+
+        auto query_string = "enforce: Process.location != Process._id0 { Process.location, myClock[2, 10]:100 }";
+
+        auto query = f.parse_query(query_string).intermediate;
+
+        REQUIRE(query.get_kind() == UTAP::Constants::ENFORCE);
+        CHECK(query_string == query.str());
+    }
+
+
     SUBCASE("Correct types")
     {
         // NB: Whitespace is significant since it must match the pretty-printer.

--- a/test/test_prettyprint.cpp
+++ b/test/test_prettyprint.cpp
@@ -323,7 +323,7 @@ TEST_CASE("Post incrementing an identifier should not require parenthesis")
     CHECK(expr.str() == "foo++");
 }
 
-TEST_CASE("Enforce query")
+TEST_CASE("acontrol query")
 {
     auto f = document_fixture{}
                  .add_default_process()
@@ -341,11 +341,11 @@ TEST_CASE("Enforce query")
     SUBCASE("Support of locations")
     {
 
-        auto query_string = "enforce: Process.location != Process._id0 { Process.location, myClock[2, 10]:100 }";
+        const std::string query_string = "acontrol: A[] Process.location != Process._id0 { Process.location, myClock[2, 10]:100 }";
 
-        auto query = f.parse_query(query_string).intermediate;
+        auto query = f.parse_query(query_string.data()).intermediate;
 
-        REQUIRE(query.get_kind() == UTAP::Constants::ENFORCE);
+        REQUIRE(query.get_kind() == UTAP::Constants::ACONTROL);
         CHECK(query_string == query.str());
     }
 
@@ -353,7 +353,7 @@ TEST_CASE("Enforce query")
     SUBCASE("Correct types")
     {
         // NB: Whitespace is significant since it must match the pretty-printer.
-        const std::string query_string = "enforce: myDouble < 1 "
+        const std::string query_string = "acontrol: A[] myDouble < 1 "
                                          "{ "
                                          "myInt[2 + 2, 10], "
                                          "myConstrainedInt[1, 2 * 5], "
@@ -362,7 +362,7 @@ TEST_CASE("Enforce query")
 
         auto query1 = f.parse_query(query_string.data()).intermediate;
 
-        REQUIRE(query1.get_kind() == UTAP::Constants::ENFORCE);
+        REQUIRE(query1.get_kind() == UTAP::Constants::ACONTROL);
         CHECK(query_string == query1.str());
     }
 
@@ -371,36 +371,36 @@ TEST_CASE("Enforce query")
         // Expressions involving clocks typecheck as invariants.
         // Invariants aren't considered boolean expressions for some reason. I don't consider this my problem.
         // The workaround is to add a floating-point number to the clock to appease the type checker.
-        const std::string query_string = "enforce: myClock + 0.0 < 10 && myClock + 0.0 > 0 { myClock[-1, 10]:100 }";
+        const std::string query_string = "acontrol: A[] myClock + 0.0 < 10 && myClock + 0.0 > 0 { myClock[-1, 10]:100 }";
 
         auto query1 = f.parse_query(query_string.data()).intermediate;
 
         // And then I have to respect that the prettyprinter prints `0` instead of `0.0` for doubles.
         // Also not my problem. And no, adding `0` in the query does not work.
-        const std::string expected_string = "enforce: myClock + 0 < 10 && myClock + 0 > 0 { myClock[-1, 10]:100 }";
-        REQUIRE(query1.get_kind() == UTAP::Constants::ENFORCE);
+        const std::string expected_string = "acontrol: A[] myClock + 0 < 10 && myClock + 0 > 0 { myClock[-1, 10]:100 }";
+        REQUIRE(query1.get_kind() == UTAP::Constants::ACONTROL);
         CHECK(expected_string == query1.str());
     }
 
     SUBCASE("Invalid condition to enforce")
     {
-        const auto query_string = "enforce: (-2.2) { }";
+        const auto query_string = "acontrol: A[] (-2.2) { }";
         REQUIRE_THROWS_WITH(f.parse_query(query_string).intermediate, "$Type_error");
 
-        const auto query_string2 = "enforce: myChannel { }";
+        const auto query_string2 = "acontrol: A[] myChannel { }";
         REQUIRE_THROWS_WITH(f.parse_query(query_string2).intermediate, "$Type_error");
     }
 
     SUBCASE("Invalid number of divisions")
     {
-        const auto query_string = "enforce: myDouble < 1 {  myDouble[M_PI, 21 * 100]:1.5 }";
+        const auto query_string = "acontrol: A[] myDouble < 1 {  myDouble[M_PI, 21 * 100]:1.5 }";
         REQUIRE_THROWS_WITH(f.parse_query(query_string), "$syntax_error: $unexpected T_FLOATING, $expecting T_NAT");
 
         // Don't know why it still says "T_FLOATING" here.
-        const auto query_string2 = "enforce: myDouble < 1 { myDouble[M_PI, 21 * 100]:myChannel }";
+        const auto query_string2 = "acontrol: A[] myDouble < 1 { myDouble[M_PI, 21 * 100]:myChannel }";
         REQUIRE_THROWS_WITH(f.parse_query(query_string2), "$syntax_error: $unexpected T_FLOATING, $expecting T_NAT");
 
-        const auto query_string3 = "enforce: myDouble < 1 { myDouble[M_PI, 21 * 100]:myClock }";
+        const auto query_string3 = "acontrol: A[] myDouble < 1 { myDouble[M_PI, 21 * 100]:myClock }";
         REQUIRE_THROWS_WITH(f.parse_query(query_string3), "$syntax_error: $unexpected T_FLOATING, $expecting T_NAT");
     }
 }

--- a/test/test_prettyprint.cpp
+++ b/test/test_prettyprint.cpp
@@ -338,32 +338,31 @@ TEST_CASE("acontrol query")
     const auto foo = f.get_errors();
     REQUIRE(f.get_errors().empty());
 
-    SUBCASE("Support of locations")
-    {
-
-        const std::string query_string = "acontrol: A[] Process.location != Process._id0 { Process.location, myClock[2, 10]:100 }";
-
-        auto query = f.parse_query(query_string.data()).intermediate;
-
-        REQUIRE(query.get_kind() == UTAP::Constants::ACONTROL);
-        CHECK(query_string == query.str());
-    }
-
-
-    SUBCASE("Correct types")
+    SUBCASE("Basics")
     {
         // NB: Whitespace is significant since it must match the pretty-printer.
         const std::string query_string = "acontrol: A[] myDouble < 1 "
                                          "{ "
                                          "myInt[2 + 2, 10], "
                                          "myConstrainedInt[1, 2 * 5], "
-                                         "myDouble[M_PI, 21 * 100]:100 "
+                                         "myDouble[M_PI, 2.1 * 100]:100 "
                                          "}";
 
         auto query1 = f.parse_query(query_string.data()).intermediate;
 
         REQUIRE(query1.get_kind() == UTAP::Constants::ACONTROL);
         CHECK(query_string == query1.str());
+    }
+
+    SUBCASE("Support of locations")
+    {
+        const std::string query_string =
+            "acontrol: A[] Process.location != Process._id0 { Process.location, myClock[2, 10]:100 }";
+
+        auto query = f.parse_query(query_string.data()).intermediate;
+
+        REQUIRE(query.get_kind() == UTAP::Constants::ACONTROL);
+        CHECK(query_string == query.str());
     }
 
     SUBCASE("Mixing some clocks in there")

--- a/test/test_prettyprint.cpp
+++ b/test/test_prettyprint.cpp
@@ -354,6 +354,22 @@ TEST_CASE("Enforce query")
         CHECK(query_string == query1.str());
     }
 
+    SUBCASE("Mixing some clocks in there")
+    {
+        // Expressions involving clocks typecheck as invariants.
+        // Invariants aren't considered boolean expressions for some reason. I don't consider this my problem.
+        // The workaround is to add a floating-point number to the clock to appease the type checker.
+        const std::string query_string = "enforce: myClock + 0.0 < 10 && myClock + 0.0 > 0 { myClock[-1, 10]:100 }";
+
+        auto query1 = f.parse_query(query_string.data()).intermediate;
+
+        // And then I have to respect that the prettyprinter prints `0` instead of `0.0` for doubles.
+        // Also not my problem. And no, adding `0` in the query does not work.
+        const std::string expected_string = "enforce: myClock + 0 < 10 && myClock + 0 > 0 { myClock[-1, 10]:100 }";
+        REQUIRE(query1.get_kind() == UTAP::Constants::ENFORCE);
+        CHECK(expected_string == query1.str());
+    }
+
     SUBCASE("Invalid condition to enforce")
     {
         const auto query_string = "enforce: (-2.2) { }";


### PR DESCRIPTION
Syntax for the `acontrol A[]` query. With tests & everything. 